### PR TITLE
Deserializer rework

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -9,7 +9,7 @@ use pom::char_class;
 use pom::parser::*;
 use serde::de::{self, Deserializer as Deserializer_, DeserializeSeed, Visitor};
 
-type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {

--- a/src/de.rs
+++ b/src/de.rs
@@ -4,9 +4,8 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::str::FromStr;
 
-use pom::{DataInput, Input};
-use pom::char_class;
-use pom::parser::*;
+use parse::Bytes;
+
 use serde::de::{self, Deserializer as Deserializer_, DeserializeSeed, Visitor};
 
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -68,17 +67,24 @@ impl StdError for Error {
 }
 
 pub struct Deserializer<'de> {
-    input: DataInput<'de, u8>,
+    bytes: Bytes<'de>,
 }
 
 impl<'de> Deserializer<'de> {
     pub fn from_str(input: &'de str) -> Self {
         Deserializer {
-            input: DataInput::new(input.as_bytes()),
+            bytes: Bytes::new(input.as_bytes()),
         }
     }
+
+    pub fn from_bytes(input: &'de [u8]) -> Self {
+        Deserializer {
+            bytes: Bytes::new(input),
+        }
+    }
+
     pub fn remainder(&self) -> Cow<str> {
-        String::from_utf8_lossy(&self.input.data[self.input.position..])
+        String::from_utf8_lossy(&self.bytes.bytes())
     }
 }
 
@@ -87,63 +93,24 @@ pub fn from_str<'a, T>(s: &'a str) -> Result<T>
 {
     let mut deserializer = Deserializer::from_str(s);
     let t = T::deserialize(&mut deserializer)?;
-    if deserializer.input.position == deserializer.input.data.len() {
-        Ok(t)
-    } else {
-        Err(Error::TrailingCharacters)
-    }
+
+    deserializer.end()?;
+
+    Ok(t)
 }
 
 impl<'de> Deserializer<'de> {
-    fn parse_unsigned<T>(&mut self) -> Result<T>
-        where T: 'static + FromStr, T::Err: fmt::Debug
-    {
-        let parser = one_of(b"0123456789").repeat(1..);
-        parser.convert(|bytes| String::from_utf8(bytes))
-              .convert(|string| FromStr::from_str(&string))
-              .parse(&mut self.input)
-              .map_err(|_| Error::ExpectedInteger)
+    /// Check if the remaining bytes are whitespace only,
+    /// otherwise return an error.
+    pub fn end(&mut self) -> Result<()> {
+        self.bytes.skip_ws();
+
+        if self.bytes.bytes().is_empty() {
+            Ok(())
+        } else {
+            Err(Error::TrailingCharacters)
+        }
     }
-
-    fn parse_signed<T>(&mut self) -> Result<T>
-        where T: 'static + FromStr, T::Err: fmt::Debug
-    {
-        let parser = one_of(b"+-").opt() +
-                     one_of(b"0123456789").repeat(1..);
-        parser.collect()
-              .convert(|bytes| String::from_utf8(bytes))
-              .convert(|string| FromStr::from_str(&string))
-              .parse(&mut self.input)
-              .map_err(|_| Error::ExpectedInteger)
-    }
-
-    fn parse_float<T>(&mut self) -> Result<T>
-        where T: 'static + FromStr, T::Err: fmt::Debug
-    {
-        let integer = one_of(b"123456789") - one_of(b"0123456789").repeat(0..) | sym(b'0');
-        let frac = sym(b'.') + one_of(b"0123456789").repeat(1..);
-        let exp = one_of(b"eE") + one_of(b"+-").opt() + one_of(b"0123456789").repeat(1..);
-        let parser = sym(b'-').opt() + integer + frac.opt() + exp.opt();
-
-        parser.collect()
-              .convert(|bytes| String::from_utf8(bytes))
-              .convert(|string| FromStr::from_str(&string))
-              .parse(&mut self.input)
-              .map_err(|_| Error::ExpectedFloat)
-    }
-
-    fn consume(&mut self, what: &'static str) -> Result<()> {
-        let parser = seq(what.as_bytes()).discard();
-        parser.parse(&mut self.input)
-              .map_err(|_| Error::Syntax)
-    }
-}
-
-fn space<'a>() -> Parser<'a, u8, ()> {
-    one_of(b" \t\r\n").repeat(0..).discard()
-}
-fn comma<'a>() -> Parser<'a, u8, u8> {
-    space() * sym(b',') - space()
 }
 
 impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
@@ -158,98 +125,73 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        match seq(b"true").parse(&mut self.input) {
-            Ok(_) => visitor.visit_bool(true),
-            Err(_) => match seq(b"false").parse(&mut self.input) {
-                Ok(_) => visitor.visit_bool(false),
-                Err(_) => Err(Error::ExpectedBoolean)
-            }
-        }
+        visitor.visit_bool(self.bytes.bool()?)
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_i8(self.parse_signed()?)
+        visitor.visit_i8(self.bytes.signed_integer()?)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_i16(self.parse_signed()?)
+        visitor.visit_i8(self.bytes.signed_integer()?)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_i32(self.parse_signed()?)
+        visitor.visit_i32(self.bytes.signed_integer()?)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_i64(self.parse_signed()?)
+        visitor.visit_i64(self.bytes.signed_integer()?)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_u8(self.parse_unsigned()?)
+        visitor.visit_u8(self.bytes.unsigned_integer()?)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_u16(self.parse_unsigned()?)
+        visitor.visit_u16(self.bytes.unsigned_integer()?)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_u32(self.parse_unsigned()?)
+        visitor.visit_u32(self.bytes.unsigned_integer()?)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_u64(self.parse_unsigned()?)
+        visitor.visit_u64(self.bytes.unsigned_integer()?)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_f32(self.parse_float()?)
+        visitor.visit_f32(self.bytes.float()?)
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        visitor.visit_f64(self.parse_float()?)
+        visitor.visit_f64(self.bytes.float()?)
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        let parser = sym(b'\'') * take(1);
-        match parser.parse(&mut self.input) {
-            Ok(c) => {
-                let rv = if c[0] == b'\\' {
-                    match take(1).parse(&mut self.input) {
-                        Ok(ref c) if c[0] == b'\'' => visitor.visit_char('\''),
-                        Ok(ref c) if c[0] == b'\\' => visitor.visit_char('\\'),
-                        Ok(_) => Err(Error::InvalidEscape),
-                        Err(_) => Err(Error::InvalidEscape),
-                    }
-                } else {
-                    visitor.visit_char(c[0] as char)
-                };
-
-                sym(b'\'').parse(&mut self.input).map_err(|_| Error::ExpectedChar)?;
-
-                rv
-            },
-            Err(_) => Err(Error::ExpectedChar)
-        }
+        visitor.visit_char(self.bytes.char()?)
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -276,34 +218,34 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.deserialize_str(visitor)
     }
 
-    // The `Serializer` implementation on the previous page serialized byte
-    // arrays as JSON arrays of bytes. Handle that representation here.
-    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        unimplemented!()
+        self.deserialize_seq(visitor)
     }
 
-    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        unimplemented!()
+        self.deserialize_seq(visitor)
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
         where V: Visitor<'de>
     {
-        match seq(b"None").discard().parse(&mut self.input) {
-            Ok(_) => visitor.visit_none(),
-            Err(_) => match (seq(b"Some(") - space()).discard().parse(&mut self.input) {
-                Ok(_) => {
-                    let value = visitor.visit_some(&mut *self)?;
-                    self.consume(")")
-                        .map(|_| value)
-                        .map_err(|_| Error::ExpectedOptionEnd)
-                },
-                Err(_) => Err(Error::ExpectedOption),
+        if self.bytes.consume("Some(") {
+            let v = visitor.visit_some(&mut *self)?;
+
+            if self.bytes.consume(")") {
+                Ok(v)
+            } else {
+                Err(Error::ExpectedOptionEnd)
             }
+
+        } else if self.bytes.consume("None") {
+            visitor.visit_none()
+        } else {
+            Err(Error::ExpectedOption)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ extern crate serde_derive;
 
 pub mod de;
 pub mod ser;
+
+pub mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ extern crate serde_derive;
 pub mod de;
 pub mod ser;
 
-pub mod parse;
+mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,6 +5,8 @@ use de::{Error, Result};
 
 const DIGITS: &[u8] = b"0123456789";
 const FLOAT_CHARS: &[u8] = b"0123456789.+-eE";
+const IDENT_FIRST: &[u8] = b"abcdefghijklmnopqrstuvwxyz_";
+const IDENT_CHAR: &[u8] = b"abcdefghijklmnopqrstuvwxyz_0123456789";
 const WHITE_SPACE: &[u8] = b"\n\t\r ";
 
 #[derive(Clone, Copy)]
@@ -127,6 +129,19 @@ impl<'a> Bytes<'a> {
         res
     }
 
+    pub fn identifier(&self) -> Result<&[u8]> {
+        if IDENT_FIRST.contains(&self.peek().ok_or(Error::Eof)?) {
+            let bytes = self.next_bytes_contained_in(IDENT_CHAR);
+
+            let (ident, bytes) = self.bytes.split_at(bytes);
+            self.bytes = bytes;
+
+            Ok(ident)
+        } else {
+            Err(Error::ExpectedIdentifier)
+        }
+    }
+
     pub fn next_bytes_contained_in(&self, allowed: &[u8]) -> usize {
         (0..)
             .flat_map(|i| self.bytes.get(i))
@@ -139,8 +154,6 @@ impl<'a> Bytes<'a> {
             let _ = self.advance_single();
         }
     }
-
-    pub fn option(&mut self) -> Result<Option<>>
 
     pub fn peek(&self) -> Option<u8> {
         self.bytes.get(0).map(|b| *b)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,15 +1,15 @@
 use std::ops::Neg;
-use std::str::{FromStr, from_utf8_unchecked};
+use std::str::{FromStr, from_utf8, from_utf8_unchecked};
 
 use de::{Error, Result};
 
 const DIGITS: &[u8] = b"0123456789";
 const FLOAT_CHARS: &[u8] = b"0123456789.+-eE";
-const IDENT_FIRST: &[u8] = b"abcdefghijklmnopqrstuvwxyz_";
-const IDENT_CHAR: &[u8] = b"abcdefghijklmnopqrstuvwxyz_0123456789";
+const IDENT_FIRST: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_";
+const IDENT_CHAR: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789";
 const WHITE_SPACE: &[u8] = b"\n\t\r ";
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bytes<'a> {
     bytes: &'a [u8],
     column: usize,
@@ -121,20 +121,20 @@ impl<'a> Bytes<'a> {
     {
         let num_bytes = self.next_bytes_contained_in(FLOAT_CHARS);
 
-        let res = FromStr::from_str(unsafe { from_utf8_unchecked(&self.bytes[0..num_bytes]) })
-            .map_err(|_| Error::ExpectedFloat);
+        let s = unsafe { from_utf8_unchecked(&self.bytes[0..num_bytes]) };
+        let res = FromStr::from_str(s).map_err(|_| Error::ExpectedFloat);
 
         let _ = self.advance(num_bytes);
 
         res
     }
 
-    pub fn identifier(&self) -> Result<&[u8]> {
+    pub fn identifier(&mut self) -> Result<&[u8]> {
         if IDENT_FIRST.contains(&self.peek().ok_or(Error::Eof)?) {
             let bytes = self.next_bytes_contained_in(IDENT_CHAR);
 
-            let (ident, bytes) = self.bytes.split_at(bytes);
-            self.bytes = bytes;
+            let ident = &self.bytes[..bytes];
+            let _ = self.advance(bytes);
 
             Ok(ident)
         } else {
@@ -143,10 +143,10 @@ impl<'a> Bytes<'a> {
     }
 
     pub fn next_bytes_contained_in(&self, allowed: &[u8]) -> usize {
-        (0..)
+        (0..self.bytes.len())
             .flat_map(|i| self.bytes.get(i))
-            .filter(|b| allowed.contains(b))
-            .fold(1, |acc, _| acc + 1)
+            .take_while(|b| allowed.contains(b))
+            .fold(0, |acc, _| acc + 1)
     }
 
     pub fn skip_ws(&mut self) {
@@ -159,7 +159,7 @@ impl<'a> Bytes<'a> {
         self.bytes.get(0).map(|b| *b)
     }
 
-    pub fn signed_integer<T>(&mut self) -> Result<T> where T: FromStr + Neg<Output = T> {
+    pub fn signed_integer<T>(&mut self) -> Result<T> where T: FromStr + Neg<Output=T> {
         match self.peek() {
             Some(b'+') => {
                 let _ = self.advance_single();
@@ -173,6 +173,51 @@ impl<'a> Bytes<'a> {
             }
             Some(_) => self.unsigned_integer(),
             None => Err(Error::Eof),
+        }
+    }
+
+    pub fn string(&mut self) -> Result<ParsedStr> {
+        if !self.consume("\"") {
+            return Err(Error::ExpectedString);
+        }
+
+        let (i, end_or_escape) = (0..)
+            .flat_map(|i| self.bytes.get(i))
+            .enumerate()
+            .find(|&(_, &b)| b == b'\\' || b == b'"')
+            .ok_or(Error::Eof)?;
+
+        if *end_or_escape == b'"' {
+            let s = from_utf8(&self.bytes[..i])?;
+
+            // Advance by the number of bytes of the string
+            // + 1 for the `"`.
+            let _ = self.advance(i + 1);
+
+            Ok(ParsedStr::Slice(s))
+        } else {
+            let mut i = i;
+            let mut s: Vec<_> = self.bytes[..i].to_vec();
+
+            loop {
+                let _ = self.advance(i + 1);
+                self.parse_str_escape(&mut s)?;
+
+                let (new_i, end_or_escape) = (0..)
+                    .flat_map(|i| self.bytes.get(i))
+                    .enumerate()
+                    .find(|&(_, &b)| b == b'\\' || b == b'"')
+                    .ok_or(Error::Eof)?;
+
+                i = new_i;
+                s.extend_from_slice(&self.bytes[..i]);
+
+                if *end_or_escape == b'"' {
+                    let _ = self.advance(i + 1);
+
+                    break Ok(ParsedStr::Allocated(String::from_utf8(s)?));
+                }
+            }
         }
     }
 
@@ -190,10 +235,100 @@ impl<'a> Bytes<'a> {
 
         res
     }
+
+    fn decode_hex_escape(&mut self) -> Result<u16> {
+        let mut n = 0;
+        for _ in 0..4 {
+            n = match self.eat_byte()? {
+                c @ b'0' ... b'9' => n * 16_u16 + ((c as u16) - (b'0' as u16)),
+                b'a' | b'A' => n * 16_u16 + 10_u16,
+                b'b' | b'B' => n * 16_u16 + 11_u16,
+                b'c' | b'C' => n * 16_u16 + 12_u16,
+                b'd' | b'D' => n * 16_u16 + 13_u16,
+                b'e' | b'E' => n * 16_u16 + 14_u16,
+                b'f' | b'F' => n * 16_u16 + 15_u16,
+                _ => {
+                    return Err(Error::InvalidEscape);
+                }
+            };
+        }
+
+        Ok(n)
+    }
+
+    fn parse_str_escape(&mut self, store: &mut Vec<u8>) -> Result<()> {
+        use std::iter::repeat;
+
+        match self.eat_byte()? {
+            b'"' => store.push(b'"'),
+            b'\\' => store.push(b'\\'),
+            b'b' => store.push(b'\x08'),
+            b'f' => store.push(b'\x0c'),
+            b'n' => store.push(b'\n'),
+            b'r' => store.push(b'\r'),
+            b't' => store.push(b'\t'),
+            b'u' => {
+                let c: char = match self.decode_hex_escape()? {
+                    0xDC00 ... 0xDFFF => {
+                        return Err(Error::InvalidEscape);
+                    }
+
+                    n1 @ 0xD800 ... 0xDBFF => {
+                        if self.eat_byte()? != b'\\' {
+                            return Err(Error::InvalidEscape);
+                        }
+
+                        if self.eat_byte()? != b'u' {
+                            return Err(Error::InvalidEscape);
+                        }
+
+                        let n2 = self.decode_hex_escape()?;
+
+                        if n2 < 0xDC00 || n2 > 0xDFFF {
+                            return Err(Error::InvalidEscape);
+                        }
+
+                        let n = (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000;
+
+                        match ::std::char::from_u32(n as u32) {
+                            Some(c) => c,
+                            None => {
+                                return Err(Error::InvalidEscape);
+                            }
+                        }
+                    }
+
+                    n => {
+                        match ::std::char::from_u32(n as u32) {
+                            Some(c) => c,
+                            None => {
+                                return Err(Error::InvalidEscape);
+                            }
+                        }
+                    }
+                };
+
+                let char_start = store.len();
+                store.extend(repeat(0).take(c.len_utf8()));
+                c.encode_utf8(&mut store[char_start..]);
+            }
+            _ => {
+                return Err(Error::InvalidEscape);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Position {
     pub col: usize,
     pub line: usize,
+}
+
+#[derive(Clone, Debug)]
+pub enum ParsedStr<'a> {
+    Allocated(String),
+    Slice(&'a str),
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,135 @@
+use std::ops::Neg;
+use std::str::{FromStr, from_utf8_unchecked};
+
+use de::{Error, Result};
+
+const DIGITS: &[u8] = b"0123456789";
+const FLOAT_CHARS: &[u8] = b"0123456789.+-eE";
+const WHITE_SPACE: &[u8] = b"\n\t\r ";
+
+pub struct Bytes<'a> {
+    bytes: &'a [u8],
+    column: usize,
+    line: usize,
+}
+
+impl<'a> Bytes<'a> {
+    pub fn advance(&mut self, bytes: usize) -> Result<()> {
+        for _ in 0..bytes {
+            self.advance_single()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn advance_single(&mut self) -> Result<()> {
+        if self.peek().ok_or(Error::Eof)? == b'\n' {
+            self.line += 1;
+            self.column = 0;
+        } else {
+            self.column += 1;
+        }
+
+        self.bytes = &self.bytes[1..];
+
+        Ok(())
+    }
+
+    pub fn comma(&mut self) -> bool {
+        if self.consume(",") {
+            self.skip_ws();
+
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn consume(&mut self, s: &str) -> bool {
+        if s.bytes().enumerate().all(|(i, b)| self.bytes.get(i).map(|t| *t == b).unwrap_or(false)) {
+            let _ = self.advance(s.len());
+
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn eat_byte(&mut self) -> Result<u8> {
+        if let Some(peek) = self.peek() {
+            let _ = self.advance_single();
+
+            Ok(peek)
+        } else {
+            Err(Error::Eof)
+        }
+    }
+
+    pub fn float<T>(&mut self) -> Result<T>
+        where T: FromStr
+    {
+        let num_bytes = self.next_bytes_contained_in(FLOAT_CHARS);
+
+        let res = FromStr::from_str(unsafe { from_utf8_unchecked(&self.bytes[0..num_bytes]) })
+            .map_err(|_| Error::ExpectedFloat);
+
+        let _ = self.advance(num_bytes);
+
+        res
+    }
+
+    pub fn next_bytes_contained_in(&self, allowed: &[u8]) -> usize {
+        (0..)
+            .flat_map(|i| self.bytes.get(i))
+            .filter(|b| allowed.contains(b))
+            .fold(1, |acc, _| acc + 1)
+    }
+
+    pub fn skip_ws(&mut self) {
+        while self.peek().map(|c| WHITE_SPACE.contains(&c)).unwrap_or(false) {
+            let _ = self.advance_single();
+        }
+    }
+
+    pub fn peek(&self) -> Option<u8> {
+        self.bytes.get(0).map(|b| *b)
+    }
+
+    pub fn signed_integer<T>(&mut self) -> Result<T> where T: FromStr + Neg<Output = T> {
+        match self.peek() {
+            Some(b'+') => {
+                let _ = self.advance_single();
+
+                self.unsigned_integer()
+            }
+            Some(b'-') => {
+                let _ = self.advance_single();
+
+                self.unsigned_integer::<T>().map(Neg::neg)
+            }
+            Some(_) => self.unsigned_integer(),
+            None => Err(Error::Eof),
+        }
+    }
+
+    pub fn unsigned_integer<T>(&mut self) -> Result<T> where T: FromStr {
+        let num_bytes = self.next_bytes_contained_in(DIGITS);
+
+        if num_bytes == 0 {
+            return Err(Error::Eof);
+        }
+
+        let res = FromStr::from_str(unsafe { from_utf8_unchecked(&self.bytes[0..num_bytes]) })
+            .map_err(|_| Error::ExpectedInteger);
+
+        let _ = self.advance(num_bytes);
+
+        res
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Position {
+    pub col: usize,
+    pub line: usize,
+}


### PR DESCRIPTION
This PR gets rid of the parser (POM). The goal is to make deserialization faster and avoid unnecessary dependencies. It seems that RON is simple enough to be parsed without some framework; these libraries tend to have `Box<Fn>` and `Vec` all over the place.