### PR TITLE
Removed indentation from tuple variant pretty encoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ron"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -13,6 +13,12 @@ struct Config {
     float: f32,
     map: HashMap<u8, char>,
     nested: Nested,
+    var: Variant,
+}
+
+#[derive(Serialize)]
+enum Variant {
+    A(u8, &'static str),
 }
 
 #[derive(Serialize)]
@@ -35,6 +41,7 @@ fn main() {
             a: "Hello from \"RON\"".to_string(),
             b: 'b',
         },
+        var: Variant::A(!0, ""),
     }).expect("Serialization failed");
 
     file.write(s.as_bytes()).expect("Failed to write data to file");

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -297,8 +297,6 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.output += variant;
         self.output += "(";
 
-        self.start_indent();
-
         Ok(self)
     }
 


### PR DESCRIPTION
At the end of the day, we need some sort of pretty configuration (deserializable with Ron? we need to go deeper!) specifying things like:
  - type of indentation (N spaces, tab, etc)
  - type of newlines
  - making indentation for tuples
  - etc