### PR TITLE
Directly serialize f32

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -211,7 +211,8 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        self.serialize_f64(v as f64)
+        self.output += &v.to_string();
+        Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {


### PR DESCRIPTION
Currently f32 is serialized by converting to f64 first. [This results in some numbers printed with many decimal places that do not convey information](https://play.rust-lang.org/?gist=2d8e4ab9d5d8fe689fdb6490bb4721c5&version=stable). (A f32 can represent about 6 decimal places)

