### PR TITLE
Limit the pretty depth

### DIFF
--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -4,7 +4,6 @@ extern crate serde;
 
 use std::collections::HashMap;
 use std::default::Default;
-use std::fs::File;
 
 use ron::ser::{to_string_pretty, PrettyConfig};
 
@@ -33,10 +32,7 @@ struct Nested {
 }
 
 fn main() {
-    use std::io::Write;
     use std::iter::FromIterator;
-
-    let mut file = File::create("config.ron").expect("Failed to create file");
 
     let data = Config {
         float: (2.18, -1.1),
@@ -51,12 +47,12 @@ fn main() {
     };
 
     let pretty = PrettyConfig {
+        depth_limit: 2,
         separate_tuple_members: true,
         enumerate_arrays: true,
         ..PrettyConfig::default()
     };
     let s = to_string_pretty(&data, pretty).expect("Serialization failed");
 
-    file.write(s.as_bytes())
-        .expect("Failed to write data to file");
+    println!("{}", s);
 }

--- a/tests/depth_limit.rs
+++ b/tests/depth_limit.rs
@@ -1,0 +1,63 @@
+extern crate ron;
+#[macro_use]
+extern crate serde;
+
+use std::collections::HashMap;
+
+#[derive(Serialize)]
+struct Config {
+    float: (f32, f64),
+    tuple: TupleStruct,
+    map: HashMap<u8, char>,
+    nested: Nested,
+    var: Variant,
+    array: Vec<()>,
+}
+
+#[derive(Serialize)]
+struct TupleStruct((), bool);
+
+#[derive(Serialize)]
+enum Variant {
+    A(u8, &'static str),
+}
+
+#[derive(Serialize)]
+struct Nested {
+    a: String,
+    b: char,
+}
+
+const EXPECTED: &str = "(
+    float: (2.18,-1.1,),
+    tuple: ((),false,),
+    map: {8:'1',},
+    nested: (a:\"a\",b:'b',),
+    var: A(255,\"\",),
+    array: [(),(),(),],
+)";
+
+#[test]
+fn depth_limit() {
+    let data = Config {
+        float: (2.18, -1.1),
+        tuple: TupleStruct((), false),
+        map: vec![(8, '1')].into_iter().collect(),
+        nested: Nested {
+            a: "a".to_owned(),
+            b: 'b',
+        },
+        var: Variant::A(!0, ""),
+        array: vec![(); 3],
+    };
+
+    let pretty = ron::ser::PrettyConfig {
+        depth_limit: 2,
+        separate_tuple_members: true,
+        enumerate_arrays: true,
+        .. Default::default()
+    };
+    let s = ron::ser::to_string_pretty(&data, pretty);
+
+    assert_eq!(s, Ok(EXPECTED.to_string()));
+}


### PR DESCRIPTION
Fixes #92
cc @pyfisch 

Output of `cargo run --example encode`:
```yaml
(
    float: (2.18,-1.1,),
    tuple: ((),false,),
    map: {0:'1',8:'1',3:'5',1:'2',},
    nested: (a:"Hello from \"RON\"",b:'b',),
    var: A(255,"",),
    array: [(),(),(),],
)
```

Unresolved questions:
  1. should we omit the trailing comma for non-pretty output? Given that it's on the same line, it sort of makes sense. It would just affect more than just the `depth_limit` parameter.
  2. do we still want to put spaces after commas for pretty output behind the depth limit?