### PR TITLE
Add multi-line comments

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -12,6 +12,7 @@ struct Config {
     float: f32,
     map: HashMap<u8, char>,
     nested: Nested,
+    option: Option<String>,
     tuple: (u32, u32),
 }
 
@@ -21,7 +22,21 @@ struct Nested {
     b: char,
 }
 
-const CONFIG: &str = "(
+const CONFIG: &str = "
+/*
+ * RON now has multi-line (C-style) block comments!
+ * They can be freely nested:
+ * /* This is a nested comment */
+ * If you just want a single-line comment,
+ * do it like here:
+// Just put two slashes before the comment and the rest of the line
+// can be used freely!
+*/
+
+// Note that block comments can not be started in a line comment
+// (Putting a /* here will have no effect)
+
+(
     boolean: true,
     float: 8.2,
     map: {
@@ -36,7 +51,8 @@ const CONFIG: &str = "(
         a: \"Decode me!\",
         b: 'z',
     ),
-    tuple: (3, 7),
+    option: Some(\t  \"Weird formatting!\" \n\n ),
+    tuple: (3 /*(2 + 1)*/, 7 /*(2 * 5 - 3)*/),
 )";
 
 fn main() {

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -48,6 +48,7 @@ pub enum ParseError {
 
     NoSuchExtension(String),
 
+    UnclosedBlockComment,
     UnexpectedByte(char),
 
     Utf8Error(Utf8Error),
@@ -106,6 +107,8 @@ impl StdError for Error {
                 ParseError::InvalidEscape(_) => "Invalid escape sequence",
 
                 ParseError::Utf8Error(ref e) => e.description(),
+                ParseError::UnclosedBlockComment => "Unclosed block comment",
+                ParseError::UnexpectedByte(_) => "Unexpected byte",
                 ParseError::TrailingCharacters => "Non-whitespace trailing characters",
 
                 _ => unimplemented!(),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -81,7 +81,7 @@ impl<'de> Deserializer<'de> {
     /// Check if the remaining bytes are whitespace only,
     /// otherwise return an error.
     pub fn end(&mut self) -> Result<()> {
-        self.bytes.skip_ws();
+        self.bytes.skip_ws()?;
 
         if self.bytes.bytes().is_empty() {
             Ok(())
@@ -111,7 +111,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
 
         if self.bytes.identifier().is_ok() {
-            self.bytes.skip_ws();
+            self.bytes.skip_ws()?;
 
             return self.deserialize_struct("", &[], visitor);
         }
@@ -255,14 +255,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 visitor.visit_some(&mut *self)
             } else {
                 if self.bytes.consume("Some") && {
-                    self.bytes.skip_ws();
+                    self.bytes.skip_ws()?;
                     self.bytes.consume("(")
                 } {
-                    self.bytes.skip_ws();
+                    self.bytes.skip_ws()?;
 
                     let v = visitor.visit_some(&mut *self)?;
 
-                    self.bytes.skip_ws();
+                    self.bytes.skip_ws()?;
 
                     if self.bytes.consume(")") {
                         Ok(v)
@@ -309,11 +309,11 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         self.bytes.consume(name);
 
-        self.bytes.skip_ws();
+        self.bytes.skip_ws()?;
 
         if self.bytes.consume("(") {
             let value = visitor.visit_newtype_struct(&mut *self)?;
-            self.bytes.comma();
+            self.bytes.comma()?;
 
             if self.bytes.consume(")") {
                 Ok(value)
@@ -331,7 +331,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         if self.bytes.consume("[") {
             let value = visitor.visit_seq(CommaSeparated::new(b']', &mut self))?;
-            self.bytes.comma();
+            self.bytes.comma()?;
 
             if self.bytes.consume("]") {
                 Ok(value)
@@ -355,7 +355,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         if self.bytes.consume("(") {
             let value = visitor.visit_seq(CommaSeparated::new(b')', &mut self))?;
-            self.bytes.comma();
+            self.bytes.comma()?;
 
             if self.bytes.consume(")") {
                 Ok(value)
@@ -386,7 +386,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         if self.bytes.consume("{") {
             let value = visitor.visit_map(CommaSeparated::new(b'}', &mut self))?;
-            self.bytes.comma();
+            self.bytes.comma()?;
 
             if self.bytes.consume("}") {
                 Ok(value)
@@ -409,11 +409,11 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         self.bytes.consume(name);
 
-        self.bytes.skip_ws();
+        self.bytes.skip_ws()?;
 
         if self.bytes.consume("(") {
             let value = visitor.visit_map(CommaSeparated::new(b')', &mut self))?;
-            self.bytes.comma();
+            self.bytes.comma()?;
 
             if self.bytes.consume(")") {
                 Ok(value)
@@ -472,7 +472,7 @@ impl<'a, 'de> CommaSeparated<'a, 'de> {
     }
 
     fn has_element(&mut self) -> Result<bool> {
-        self.de.bytes.skip_ws();
+        self.de.bytes.skip_ws()?;
 
         Ok(self.had_comma && self.de.bytes.peek_or_eof()? != self.terminator)
     }
@@ -488,7 +488,7 @@ impl<'de, 'a> de::SeqAccess<'de> for CommaSeparated<'a, 'de> {
         if self.has_element()? {
             let res = seed.deserialize(&mut *self.de)?;
 
-            self.had_comma = self.de.bytes.comma();
+            self.had_comma = self.de.bytes.comma()?;
 
             Ok(Some(res))
         } else {
@@ -520,14 +520,14 @@ impl<'de, 'a> de::MapAccess<'de> for CommaSeparated<'a, 'de> {
     where
         V: DeserializeSeed<'de>,
     {
-        self.de.bytes.skip_ws();
+        self.de.bytes.skip_ws()?;
 
         if self.de.bytes.consume(":") {
-            self.de.bytes.skip_ws();
+            self.de.bytes.skip_ws()?;
 
             let res = seed.deserialize(&mut *self.de)?;
 
-            self.had_comma = self.de.bytes.comma();
+            self.had_comma = self.de.bytes.comma()?;
 
             Ok(res)
         } else {
@@ -571,12 +571,12 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
     where
         T: DeserializeSeed<'de>,
     {
-        self.de.bytes.skip_ws();
+        self.de.bytes.skip_ws()?;
 
         if self.de.bytes.consume("(") {
             let val = seed.deserialize(&mut *self.de)?;
 
-            self.de.bytes.comma();
+            self.de.bytes.comma()?;
 
             if self.de.bytes.consume(")") {
                 Ok(val)
@@ -592,7 +592,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
     where
         V: Visitor<'de>,
     {
-        self.de.bytes.skip_ws();
+        self.de.bytes.skip_ws()?;
 
         self.de.deserialize_tuple(len, visitor)
     }
@@ -601,7 +601,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
     where
         V: Visitor<'de>,
     {
-        self.de.bytes.skip_ws();
+        self.de.bytes.skip_ws()?;
 
         self.de.deserialize_struct("", fields, visitor)
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,7 @@
 /// Deserialization module.
 ///
 pub use self::error::{Error, ParseError, Result};
+pub use parse::Position;
 
 use std::borrow::Cow;
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ Serializing / Deserializing is as simple as calling `to_string` / `from_str`.
 
 !*/
 
+#![deny(unused_must_use)]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -532,15 +532,14 @@ impl<'a> Bytes<'a> {
 
                         let _ = self.advance(bytes);
 
-                        println!("{}: {}", level, self.bytes.iter().map(|&b| b as char).take(2).collect::<String>());
-
                         // check whether / or * and take action
                         if self.consume("/*") {
                             level += 1;
                         } else if self.consume("*/") {
                             level -= 1;
                         } else {
-                            self.eat_byte()?;
+                            self.eat_byte()
+                                .map_err(|_| self.error(ParseError::UnclosedBlockComment))?;
                         }
                     }
                 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -30,7 +30,7 @@ impl<'a> Bytes<'a> {
             line: 1,
         };
 
-        b.skip_ws();
+        b.skip_ws()?;
         // Loop over all extensions attributes
         loop {
             let attribute = b.extensions()?;
@@ -40,7 +40,7 @@ impl<'a> Bytes<'a> {
             }
 
             b.exts |= attribute;
-            b.skip_ws();
+            b.skip_ws()?;
         }
 
         Ok(b)
@@ -125,15 +125,15 @@ impl<'a> Bytes<'a> {
         Ok(c)
     }
 
-    pub fn comma(&mut self) -> bool {
-        self.skip_ws();
+    pub fn comma(&mut self) -> Result<bool> {
+        self.skip_ws()?;
 
         if self.consume(",") {
-            self.skip_ws();
+            self.skip_ws()?;
 
-            true
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -172,18 +172,20 @@ impl<'a> Bytes<'a> {
         }
     }
 
-    fn consume_all(&mut self, all: &[&str]) -> bool {
+    fn consume_all(&mut self, all: &[&str]) -> Result<bool> {
         all.iter()
             .map(|elem| {
                 if self.consume(elem) {
-                    self.skip_ws();
+                    self.skip_ws()?;
 
-                    true
+                    Ok(true)
                 } else {
-                    false
+                    Ok(false)
                 }
             })
-            .all(|b| b)
+            .fold(Ok(true), |acc, x| {
+                acc.and_then(|val| x.map(|x| x && val))
+            })
     }
 
     pub fn eat_byte(&mut self) -> Result<u8> {
@@ -220,11 +222,11 @@ impl<'a> Bytes<'a> {
             return Ok(Extensions::empty());
         }
 
-        if !self.consume_all(&["#", "!", "[", "enable", "("]) {
+        if !self.consume_all(&["#", "!", "[", "enable", "("])? {
             return self.err(ParseError::ExpectedAttribute);
         }
 
-        self.skip_ws();
+        self.skip_ws()?;
         let mut extensions = Extensions::empty();
 
         loop {
@@ -237,7 +239,7 @@ impl<'a> Bytes<'a> {
 
             extensions |= extension;
 
-            let comma = self.comma();
+            let comma = self.comma()?;
 
             // If we have no comma but another item, return an error
             if !comma && self.check_ident_char(0) {
@@ -252,9 +254,9 @@ impl<'a> Bytes<'a> {
             }
         }
 
-        self.skip_ws();
+        self.skip_ws()?;
 
-        match self.consume_all(&[")", "]"]) {
+        match self.consume_all(&[")", "]"])? {
             true => Ok(extensions),
             false => Err(self.error(ParseError::ExpectedAttributeEnd)),
         }
@@ -294,7 +296,7 @@ impl<'a> Bytes<'a> {
             .fold(0, |acc, _| acc + 1)
     }
 
-    pub fn skip_ws(&mut self) {
+    pub fn skip_ws(&mut self) -> Result<()> {
         while self.peek()
             .map(|c| WHITE_SPACE.contains(&c))
             .unwrap_or(false)
@@ -302,9 +304,11 @@ impl<'a> Bytes<'a> {
             let _ = self.advance_single();
         }
 
-        if self.skip_comment() {
-            self.skip_ws();
+        if self.skip_comment()? {
+            self.skip_ws()?;
         }
+
+        Ok(())
     }
 
     pub fn peek(&self) -> Option<u8> {
@@ -505,15 +509,47 @@ impl<'a> Bytes<'a> {
         Ok(c)
     }
 
-    fn skip_comment(&mut self) -> bool {
-        if self.consume("//") {
-            let bytes = self.bytes.iter().take_while(|&&b| b != b'\n').count();
+    fn skip_comment(&mut self) -> Result<bool> {
+        if self.consume("/") {
+            match self.eat_byte()? {
+                b'/' => {
+                    let bytes = self.bytes.iter().take_while(|&&b| b != b'\n').count();
 
-            let _ = self.advance(bytes);
+                    let _ = self.advance(bytes);
+                }
+                b'*' => {
+                    let mut level = 1;
 
-            true
+                    while level > 0 {
+                        let bytes = self.bytes
+                            .iter()
+                            .take_while(|&&b| b != b'/' && b != b'*')
+                            .count();
+
+                        if self.bytes.len() == 0 {
+                            return self.err(ParseError::UnclosedBlockComment);
+                        }
+
+                        let _ = self.advance(bytes);
+
+                        println!("{}: {}", level, self.bytes.iter().map(|&b| b as char).take(2).collect::<String>());
+
+                        // check whether / or * and take action
+                        if self.consume("/*") {
+                            level += 1;
+                        } else if self.consume("*/") {
+                            level -= 1;
+                        } else {
+                            self.eat_byte()?;
+                        }
+                    }
+                }
+                b => return self.err(ParseError::UnexpectedByte(b as char)),
+            }
+
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 }

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -1,0 +1,41 @@
+extern crate ron;
+
+use ron::de::Error as RonErr;
+use ron::de::ParseError;
+use ron::de::Position;
+
+#[test]
+fn test_simple() {
+    assert_eq!(ron::de::from_str("/*
+ * We got a hexadecimal number here!
+ *
+ */0x507"
+    ), Ok(0x507));
+}
+
+#[test]
+fn test_nested() {
+    assert_eq!(ron::de::from_str("/*
+        /* quite * some * nesting * going * on * /* here /* (yeah, maybe a bit too much) */ */ */
+    */
+    // The actual value comes.. /*
+    // very soon, these are just checks that */
+    // multi-line comments don't trigger in line comments /*
+\"THE VALUE\" /* This is the value /* :) */ */
+    "
+    ), Ok("THE VALUE".to_owned()));
+}
+
+#[test]
+fn test_unclosed() {
+    assert_eq!(ron::de::from_str::<String>("/*
+        /* quite * some * nesting * going * on * /* here /* (yeah, maybe a bit too much) */ */ */
+    */
+    // The actual value comes.. /*
+    // very soon, these are just checks that */
+    // multi-line comments don't trigger in line comments /*
+/* Unfortunately, this comment won't get closed :(
+\"THE VALUE (which is invalid)\"
+"
+    ), Err(RonErr::Parser(ParseError::UnclosedBlockComment, Position { col: 1, line: 9 })));
+}

--- a/tests/depth_limit.rs
+++ b/tests/depth_limit.rs
@@ -55,7 +55,7 @@ fn depth_limit() {
         depth_limit: 2,
         separate_tuple_members: true,
         enumerate_arrays: true,
-        .. Default::default()
+        ..Default::default()
     };
     let s = ron::ser::to_string_pretty(&data, pretty);
 

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -61,7 +61,10 @@ fn test_chars() {
     assert_eq!(to_string(&'ö').unwrap(), "'ö'");
     assert_eq!(to_string(&'ü').unwrap(), "'ü'");
     assert_eq!(to_string(&'\u{715}').unwrap(), "'\u{715}'");
-    assert_eq!(from_str::<char>("'\u{715}'").unwrap(), from_str("'\\u{715}'").unwrap());
+    assert_eq!(
+        from_str::<char>("'\u{715}'").unwrap(),
+        from_str("'\\u{715}'").unwrap()
+    );
 }
 
 #[test]

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -69,7 +69,7 @@ fn roundtrip_pretty() {
 
     let pretty = ron::ser::PrettyConfig {
         enumerate_arrays: true,
-        .. Default::default()
+        ..Default::default()
     };
     let serial = ron::ser::to_string_pretty(&value, pretty).unwrap();
 


### PR DESCRIPTION
Fixes #97 

* [x] Add multi-line comment parsing
* [x] Add tests
* [ ] Update grammar
* [ ] Decide how to handle additions to the specification