### PR TITLE
Allow whitespace after enum variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ron"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -556,6 +556,8 @@ impl<'de, 'a> de::EnumAccess<'de> for Enum<'a, 'de> {
     where
         V: DeserializeSeed<'de>,
     {
+        self.de.bytes.skip_ws()?;
+
         let value = seed.deserialize(&mut *self.de)?;
 
         Ok((value, self))


### PR DESCRIPTION
Somewhat similar to #103 and annoying