### PR TITLE
Use base64 for `serde_bytes` annotated fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ exclude = ["bors.toml", ".travis.yml"]
 name = "ron"
 
 [dependencies]
+base64 = "^0.9.2"
 bitflags = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dev-dependencies]
+serde_bytes = "0.10"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ron"
-version = "0.2.2"
+version = "0.3.0"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -4,6 +4,8 @@ use std::io;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
+use base64;
+
 use serde::de;
 
 use parse::Position;
@@ -20,6 +22,7 @@ pub enum Error {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParseError {
+    Base64Error(base64::DecodeError),
     Eof,
     ExpectedArray,
     ExpectedArrayEnd,
@@ -79,6 +82,7 @@ impl StdError for Error {
             Error::IoError(ref s) => s,
             Error::Message(ref e) => e,
             Error::Parser(ref kind, _) => match *kind {
+                ParseError::Base64Error(ref e) => e.description(),
                 ParseError::Eof => "Unexpected end of file",
                 ParseError::ExpectedArray => "Expected array",
                 ParseError::ExpectedArrayEnd => "Expected end of array",

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -1,3 +1,5 @@
+extern crate serde_bytes;
+
 use super::*;
 
 #[derive(Debug, PartialEq, Deserialize)]
@@ -18,6 +20,14 @@ enum MyEnum {
     B(bool),
     C(bool, f32),
     D { a: i32, b: i32 },
+}
+
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct BytesStruct {
+    small: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    large: Vec<u8>,
 }
 
 #[test]
@@ -273,4 +283,12 @@ fn implicit_some() {
 #[test]
 fn ws_tuple_newtype_variant() {
     assert_eq!(Ok(MyEnum::B(true)), from_str("B  ( \n true \n ) "));
+}
+
+#[test]
+fn test_byte_stream() {
+    assert_eq!(
+        Ok(BytesStruct{ small: vec![1, 2], large: vec![1, 2, 3, 4] }),
+        from_str("BytesStruct( small:[1, 2], large:\"AQIDBA==\" )"),
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ Serializing / Deserializing is as simple as calling `to_string` / `from_str`.
 
 #![deny(unused_must_use)]
 
+extern crate base64;
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]


### PR DESCRIPTION
With the following `struct`, `small` will be represented as an array of `u8` and `large` as a base64 `String`.

``` rust
extern crate serde_derive;

extern crate serde;
extern crate serde_bytes;

#[derive(Serialize, Deserialize)]
struct BytesStruct {
    small: Vec<u8>,
    #[serde(with = "serde_bytes")]
    large: Vec<u8>,
}
```