### PR TITLE
Add 'r' byte to deserialize_any()

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -122,7 +122,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             b'[' => self.deserialize_seq(visitor),
             b'{' => self.deserialize_map(visitor),
             b'0'...b'9' | b'+' | b'-' | b'.' => self.deserialize_f64(visitor),
-            b'"' => self.deserialize_string(visitor),
+            b'"' | b'r' => self.deserialize_string(visitor),
             b'\'' => self.deserialize_char(visitor),
             other => self.bytes.err(ParseError::UnexpectedByte(other as char)),
         }

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -101,6 +101,9 @@ fn test_string() {
     let raw_hashes: String = from_str("r#\"String\"#").unwrap();
     assert_eq!("String", raw_hashes);
 
+    let raw_hashes_multiline: String = from_str("r#\"String with\nmultiple\nlines\n\"#").unwrap();
+    assert_eq!("String with\nmultiple\nlines\n", raw_hashes_multiline);
+
     let raw_hashes_quote: String = from_str("r##\"String with \"#\"##").unwrap();
     assert_eq!("String with \"#", raw_hashes_quote);
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -277,9 +277,15 @@ impl<'a> Bytes<'a> {
     }
 
     pub fn identifier(&mut self) -> Result<&'a [u8]> {
-        if IDENT_FIRST.contains(&self.peek_or_eof()?) {
-            let bytes = self.next_bytes_contained_in(IDENT_CHAR);
+        let next = self.peek_or_eof()?;
+        if IDENT_FIRST.contains(&next) {
+            // If the next two bytes signify the start of a raw string literal,
+            // return an error.
+            if next == b'r' && (self.bytes[1] == b'"' || self.bytes[1] == b'#') {
+                return self.err(ParseError::ExpectedIdentifier);
+            }
 
+            let bytes = self.next_bytes_contained_in(IDENT_CHAR);
             let ident = &self.bytes[..bytes];
             let _ = self.advance(bytes);
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -281,8 +281,11 @@ impl<'a> Bytes<'a> {
         if IDENT_FIRST.contains(&next) {
             // If the next two bytes signify the start of a raw string literal,
             // return an error.
-            if next == b'r' && (self.bytes[1] == b'"' || self.bytes[1] == b'#') {
-                return self.err(ParseError::ExpectedIdentifier);
+            if next == b'r' {
+                let second = self.bytes.get(1).ok_or(self.error(ParseError::Eof))?;
+                if *second == b'"' || *second == b'#' {
+                    return self.err(ParseError::ExpectedIdentifier);
+                }
             }
 
             let bytes = self.next_bytes_contained_in(IDENT_CHAR);

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,0 +1,65 @@
+extern crate ron;
+
+use std::collections::BTreeMap;
+
+use ron::value::{Number, Value};
+
+#[test]
+fn bool() {
+    assert_eq!(Value::from_str("true"), Ok(Value::Bool(true)));
+    assert_eq!(Value::from_str("false"), Ok(Value::Bool(false)));
+}
+
+#[test]
+fn char() {
+    assert_eq!(Value::from_str("'a'"), Ok(Value::Char('a')));
+}
+
+#[test]
+fn map() {
+    let mut map = BTreeMap::new();
+    map.insert(Value::Char('a'), Value::Number(Number::new(1f64)));
+    map.insert(Value::Char('b'), Value::Number(Number::new(2f64)));
+    assert_eq!(Value::from_str("{ 'a': 1, 'b': 2 }"), Ok(Value::Map(map)));
+}
+
+#[test]
+fn number() {
+    assert_eq!(Value::from_str("42"), Ok(Value::Number(Number::new(42f64))));
+    assert_eq!(Value::from_str("3.1415"), Ok(Value::Number(Number::new(3.1415f64))));
+}
+
+#[test]
+fn option() {
+    let opt = Some(Box::new(Value::Char('c')));
+    assert_eq!(Value::from_str("Some('c')"), Ok(Value::Option(opt)));
+}
+
+#[test]
+fn string() {
+    let normal = "\"String\"";
+    assert_eq!(Value::from_str(normal), Ok(Value::String("String".into())));
+
+    let raw = "r\"Raw String\"";
+    assert_eq!(Value::from_str(raw), Ok(Value::String("Raw String".into())));
+
+    let raw_hashes = "r#\"Raw String\"#";
+    assert_eq!(Value::from_str(raw_hashes), Ok(Value::String("Raw String".into())));
+
+    let raw_escaped = "r##\"Contains \"#\"##";
+    assert_eq!(Value::from_str(raw_escaped), Ok(Value::String("Contains \"#".into())));
+
+    let raw_multi_line = "r\"Multi\nLine\"";
+    assert_eq!(Value::from_str(raw_multi_line), Ok(Value::String("Multi\nLine".into())));
+}
+
+#[test]
+fn seq() {
+    let seq = vec![Value::Number(Number::new(1f64)), Value::Number(Number::new(2f64))];
+    assert_eq!(Value::from_str("[1, 2]"), Ok(Value::Seq(seq)));
+}
+
+#[test]
+fn unit() {
+    assert_eq!(Value::from_str("()"), Ok(Value::Unit));
+}


### PR DESCRIPTION
### Fixed

* Update pattern in `deserialize_any()` to accommodate for raw string literals.

Fixes #113.