### PR TITLE
Reexport `Value` at  root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,5 +69,6 @@ extern crate serde;
 pub mod de;
 pub mod ser;
 pub mod value;
+pub use value::Value;
 
 mod parse;


### PR DESCRIPTION
Hi! As a client of `ron`, I'd love to be able to use `ron::Value` :0)