### PR TITLE
Be smarter about integer deserialization

### DIFF
--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -305,3 +305,18 @@ fn test_numbers() {
         from_str("[1_234, 12_345, 1_2_3_4_5_6, 1_234_567, 5_55_55_5]"),
     );
 }
+
+fn de_any_number(s: &str) -> AnyNum {
+    let mut bytes = Bytes::new(s.as_bytes()).unwrap();
+
+    bytes.any_num().unwrap()
+}
+
+#[test]
+fn test_any_number_precision() {
+    assert_eq!(de_any_number("1"), AnyNum::U8(1));
+    assert_eq!(de_any_number("+1"), AnyNum::I8(1));
+    assert_eq!(de_any_number("-1"), AnyNum::I8(-1));
+    assert_eq!(de_any_number("-1.0"), AnyNum::F32(-1.0));
+    assert_eq!(de_any_number("0.3"), AnyNum::F64(0.3));
+}

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -150,8 +150,6 @@ y: 2.0 // 2!
 }
 
 fn err<T>(kind: ParseError, line: usize, col: usize) -> Result<T> {
-    use crate::parse::Position;
-
     Err(Error::Parser(kind, Position { line, col }))
 }
 
@@ -318,5 +316,7 @@ fn test_any_number_precision() {
     assert_eq!(de_any_number("+1"), AnyNum::I8(1));
     assert_eq!(de_any_number("-1"), AnyNum::I8(-1));
     assert_eq!(de_any_number("-1.0"), AnyNum::F32(-1.0));
+    assert_eq!(de_any_number("1."), AnyNum::F32(1.));
+    assert_eq!(de_any_number("-1."), AnyNum::F32(-1.));
     assert_eq!(de_any_number("0.3"), AnyNum::F64(0.3));
 }

--- a/tests/large_number.rs
+++ b/tests/large_number.rs
@@ -5,7 +5,6 @@ fn test_large_number() {
     use ron::value::Value;
     let test_var = Value::Number(Number::new(10000000000000000000000.0f64));
     let test_ser = ron::ser::to_string(&test_var).unwrap();
-    println!("test_ser: {}", test_ser);
     let test_deser = ron::de::from_str::<Value>(&test_ser);
 
     assert_eq!(test_deser.unwrap(), Value::Number(Number::new(10000000000000000000000.0)));

--- a/tests/large_number.rs
+++ b/tests/large_number.rs
@@ -1,0 +1,12 @@
+use ron::value::Number;
+
+#[test]
+fn test_large_number() {
+    use ron::value::Value;
+    let test_var = Value::Number(Number::new(10000000000000000000000.0f64));
+    let test_ser = ron::ser::to_string(&test_var).unwrap();
+    println!("test_ser: {}", test_ser);
+    let test_deser = ron::de::from_str::<Value>(&test_ser);
+
+    assert_eq!(test_deser.unwrap(), Value::Number(Number::new(10000000000000000000000.0)));
+}


### PR DESCRIPTION
Now, `deserialize_any` will try to find the best representation possible.

This is not a very pretty implementation, but it should work well.

Fixes #100 
Fixes #155 