### PR TITLE
Use indexmap to preserve order (optional)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ branches:
     - staging
     - trying
     - master
+
+script:
+  - cargo test
+  - cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ name = "ron"
 [dependencies]
 base64 = "0.10"
 bitflags = "1"
+indexmap = { version = "1.0.2", features = ["serde-1"], optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 
 [dev-dependencies]

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt};
+use std::fmt;
 
 use serde::{
     de::{Error, MapAccess, SeqAccess, Visitor},
@@ -7,7 +7,7 @@ use serde::{
 
 use crate::{
     de,
-    value::{Number, Value},
+    value::{Map, Number, Value},
 };
 
 impl Value {
@@ -153,7 +153,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         A: MapAccess<'de>,
     {
-        let mut res: BTreeMap<Value, Value> = BTreeMap::new();
+        let mut res: Map = Map::new();
 
         while let Some(entry) = map.next_entry()? {
             res.insert(entry.0, entry.1);

--- a/src/value.rs
+++ b/src/value.rs
@@ -27,46 +27,57 @@ use std::iter::FromIterator;
 pub struct Map(MapInner);
 
 impl Map {
+    /// Creates a new, empty `Map`.
     pub fn new() -> Map {
         Default::default()
     }
 
+    /// Returns the number of elements in the map.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Returns `true` if `self.len() == 0`, `false` otherwise.
     pub fn is_empty(&self) -> usize {
         self.0.len()
     }
 
+    /// Inserts a new element, returning the previous element with this `key` if there was any.
     pub fn insert(&mut self, key: Value, value: Value) -> Option<Value> {
         self.0.insert(key, value)
     }
 
+    /// Removes an element by its `key`.
     pub fn remove(&mut self, key: &Value) -> Option<Value> {
         self.0.remove(key)
     }
 
+    /// Iterate all key-value pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&Value, &Value)> + DoubleEndedIterator {
         self.0.iter()
     }
 
+    /// Iterate all key-value pairs mutably.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Value, &mut Value)> + DoubleEndedIterator {
         self.0.iter_mut()
     }
 
+    /// Iterate all keys.
     pub fn keys(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
         self.0.keys()
     }
 
+    /// Iterate all values.
     pub fn values(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
         self.0.values()
     }
 
+    /// Iterate all values mutably.
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut Value> + DoubleEndedIterator {
         self.0.values_mut()
     }
 
+    /// Can be used to retrieve the internal map representation.
     /// Will return `None` if `indexmap` is enabled.
     pub fn as_b_tree_map(&self) -> Option<&BTreeMap<Value, Value>> {
         #[cfg(not(feature = "indexmap"))]
@@ -77,6 +88,7 @@ impl Map {
         x
     }
 
+    /// Can be used to retrieve the internal map representation.
     /// Will return `None` if `indexmap` is enabled.
     pub fn as_b_tree_map_mut(&mut self) -> Option<&mut BTreeMap<Value, Value>> {
         #[cfg(not(feature = "indexmap"))]
@@ -87,6 +99,7 @@ impl Map {
         x
     }
 
+    /// Can be used to retrieve the internal map representation.
     /// Will return `None` if `indexmap` is disabled.
     pub fn as_index_map(&self) -> Option<&indexmap::IndexMap<Value, Value>> {
         #[cfg(feature = "indexmap")]
@@ -97,6 +110,7 @@ impl Map {
         x
     }
 
+    /// Can be used to retrieve the internal map representation.
     /// Will return `None` if `indexmap` is disabled.
     pub fn as_index_map_mut(&mut self) -> Option<&mut indexmap::IndexMap<Value, Value>> {
         #[cfg(feature = "indexmap")]

--- a/tests/129_indexmap.rs
+++ b/tests/129_indexmap.rs
@@ -1,0 +1,76 @@
+#[cfg(feature = "indexmap")]
+use ron::{de::from_str, Value};
+
+#[test]
+#[cfg(feature = "indexmap")]
+fn test_order_preserved() {
+    let file = r#"(
+tasks: {
+    "debug message": Dbg(
+      msg: "test message. some text after it."
+    ),
+    "shell command": Shell(
+      command: "ls",
+      args: Some([
+        "-l",
+        "-h",
+      ]),
+      ch_dir: Some("/")
+    ),
+}
+)
+"#;
+
+    let value: Value = from_str(file).unwrap();
+    match value {
+        Value::Map(map) => match &map[&Value::String("tasks".to_owned())] {
+            Value::Map(map) => {
+                assert_eq!(
+                    *map.keys().next().unwrap(),
+                    Value::String("debug message".to_string())
+                );
+                assert_eq!(
+                    *map.keys().skip(1).next().unwrap(),
+                    Value::String("shell command".to_string())
+                );
+            }
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+
+    let file = r#"(
+tasks: {
+    "shell command": Shell(
+      command: "ls",
+      args: Some([
+        "-l",
+        "-h",
+      ]),
+      ch_dir: Some("/")
+    ),
+    "debug message": Dbg(
+      msg: "test message. some text after it."
+    ),
+}
+)
+"#;
+
+    let value: Value = from_str(file).unwrap();
+    match value {
+        Value::Map(map) => match &map[&Value::String("tasks".to_owned())] {
+            Value::Map(map) => {
+                assert_eq!(
+                    *map.keys().next().unwrap(),
+                    Value::String("shell command".to_string())
+                );
+                assert_eq!(
+                    *map.keys().skip(1).next().unwrap(),
+                    Value::String("debug message".to_string())
+                );
+            }
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,6 +1,5 @@
 use ron::value::{Map, Number, Value};
 use serde::Serialize;
-use std::collections::BTreeMap;
 
 #[test]
 fn bool() {

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,4 +1,4 @@
-use ron::value::{Number, Value};
+use ron::value::{Map, Number, Value};
 use serde::Serialize;
 use std::collections::BTreeMap;
 
@@ -15,7 +15,7 @@ fn char() {
 
 #[test]
 fn map() {
-    let mut map = BTreeMap::new();
+    let mut map = Map::new();
     map.insert(Value::Char('a'), Value::Number(Number::new(1f64)));
     map.insert(Value::Char('b'), Value::Number(Number::new(2f64)));
     assert_eq!(Value::from_str("{ 'a': 1, 'b': 2 }"), Ok(Value::Map(map)));


### PR DESCRIPTION
Introduces an optional `indexmap` feature which uses `IndexMap` in `Value::Map` to preserve the order of deserialized elements.

Fixes #129 