### PR TITLE
Don't use trailing commas when no newlines are used

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -150,13 +150,6 @@ impl Serializer {
         self.output
     }
 
-    fn is_pretty(&self) -> bool {
-        match self.pretty {
-            Some((ref config, ref pretty)) => pretty.indent < config.depth_limit,
-            None => false,
-        }
-    }
-
     fn separate_tuple_members(&self) -> bool {
         self.pretty
             .as_ref()
@@ -553,7 +546,7 @@ impl<'a> ser::SerializeTuple for &'a mut Serializer {
     fn end(self) -> Result<()> {
         if self.separate_tuple_members() {
             self.end_indent();
-        } else if self.is_pretty() {
+        } else if self.indentation_enabled() {
             self.output.pop();
             self.output.pop();
         } else {
@@ -619,7 +612,7 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
     {
         self.output += ":";
 
-        if self.is_pretty() {
+        if self.indentation_enabled() {
             self.output += " ";
         }
 
@@ -656,7 +649,7 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
         self.output += key;
         self.output += ":";
 
-        if self.is_pretty() {
+        if self.indentation_enabled() {
             self.output += " ";
         }
 

--- a/tests/117_untagged_tuple_variant.rs
+++ b/tests/117_untagged_tuple_variant.rs
@@ -54,6 +54,6 @@ enum Foo {
 fn test_vessd_case() {
     let foo_vec = vec![Foo::Bar(0); 5];
     let foo_str = to_string(&foo_vec).unwrap();
-    assert_eq!(foo_str.as_str(), "[0,0,0,0,0,]");
+    assert_eq!(foo_str.as_str(), "[0,0,0,0,0]");
     assert_eq!(from_str::<Vec<Foo>>(&foo_str).unwrap(), foo_vec);
 }

--- a/tests/123_enum_representation.rs
+++ b/tests/123_enum_representation.rs
@@ -62,7 +62,7 @@ fn test_externally_a_ser() {
         bar: 2,
         different: 3,
     };
-    let e = "VariantA(foo:1,bar:2,different:3,)";
+    let e = "VariantA(foo:1,bar:2,different:3)";
     test_ser(&v, e);
 }
 
@@ -72,7 +72,7 @@ fn test_externally_b_ser() {
         foo: 1,
         bar: 2,
     };
-    let e = "VariantB(foo:1,bar:2,)";
+    let e = "VariantB(foo:1,bar:2)";
     test_ser(&v, e);
 }
 
@@ -83,7 +83,7 @@ fn test_internally_a_ser() {
         bar: 2,
         different: 3,
     };
-    let e = "(type:\"VariantA\",foo:1,bar:2,different:3,)";
+    let e = "(type:\"VariantA\",foo:1,bar:2,different:3)";
     test_ser(&v, e);
 }
 
@@ -93,7 +93,7 @@ fn test_internally_b_ser() {
         foo: 1,
         bar: 2,
     };
-    let e = "(type:\"VariantB\",foo:1,bar:2,)";
+    let e = "(type:\"VariantB\",foo:1,bar:2)";
     test_ser(&v, e);
 }
 
@@ -104,7 +104,7 @@ fn test_adjacently_a_ser() {
         bar: 2,
         different: Inner::Foo,
     };
-    let e = "(type:\"VariantA\",content:(foo:1,bar:2,different:Foo,),)";
+    let e = "(type:\"VariantA\",content:(foo:1,bar:2,different:Foo))";
     test_ser(&v, e);
 }
 
@@ -114,7 +114,7 @@ fn test_adjacently_b_ser() {
         foo: 1,
         bar: 2,
     };
-    let e = "(type:\"VariantB\",content:(foo:1,bar:2,),)";
+    let e = "(type:\"VariantB\",content:(foo:1,bar:2))";
     test_ser(&v, e);
 }
 
@@ -125,7 +125,7 @@ fn test_untagged_a_ser() {
         bar: 2,
         different: 3,
     };
-    let e = "(foo:1,bar:2,different:3,)";
+    let e = "(foo:1,bar:2,different:3)";
     test_ser(&v, e);
 }
 
@@ -135,13 +135,13 @@ fn test_untagged_b_ser() {
         foo: 1,
         bar: 2,
     };
-    let e = "(foo:1,bar:2,)";
+    let e = "(foo:1,bar:2)";
     test_ser(&v, e);
 }
 
 #[test]
 fn test_externally_a_de() {
-    let s = "VariantA(foo:1,bar:2,different:3,)";
+    let s = "VariantA(foo:1,bar:2,different:3)";
     let e = EnumStructExternally::VariantA {
         foo: 1,
         bar: 2,
@@ -152,7 +152,7 @@ fn test_externally_a_de() {
 
 #[test]
 fn test_externally_b_de() {
-    let s = "VariantB(foo:1,bar:2,)";
+    let s = "VariantB(foo:1,bar:2)";
     let e = EnumStructExternally::VariantB {
         foo: 1,
         bar: 2,
@@ -162,7 +162,7 @@ fn test_externally_b_de() {
 
 #[test]
 fn test_internally_a_de() {
-    let s = "(type:\"VariantA\",foo:1,bar:2,different:3,)";
+    let s = "(type:\"VariantA\",foo:1,bar:2,different:3)";
     let e = EnumStructInternally::VariantA {
         foo: 1,
         bar: 2,
@@ -173,7 +173,7 @@ fn test_internally_a_de() {
 
 #[test]
 fn test_internally_b_de() {
-    let s = "(type:\"VariantB\",foo:1,bar:2,)";
+    let s = "(type:\"VariantB\",foo:1,bar:2)";
     let e = EnumStructInternally::VariantB {
         foo: 1,
         bar: 2,
@@ -183,7 +183,7 @@ fn test_internally_b_de() {
 
 #[test]
 fn test_adjacently_a_de() {
-    let s = "(type:\"VariantA\",content:(foo:1,bar:2,different:Foo,),)";
+    let s = "(type:\"VariantA\",content:(foo:1,bar:2,different:Foo))";
     let e = EnumStructAdjacently::VariantA {
         foo: 1,
         bar: 2,
@@ -194,7 +194,7 @@ fn test_adjacently_a_de() {
 
 #[test]
 fn test_adjacently_b_de() {
-    let s = "(type:\"VariantB\",content:(foo:1,bar:2,),)";
+    let s = "(type:\"VariantB\",content:(foo:1,bar:2))";
     let e = EnumStructAdjacently::VariantB {
         foo: 1,
         bar: 2,
@@ -204,7 +204,7 @@ fn test_adjacently_b_de() {
 
 #[test]
 fn test_untagged_a_de() {
-    let s = "(foo:1,bar:2,different:3,)";
+    let s = "(foo:1,bar:2,different:3)";
     let e = EnumStructUntagged::VariantA {
         foo: 1,
         bar: 2,
@@ -215,7 +215,7 @@ fn test_untagged_a_de() {
 
 #[test]
 fn test_untagged_b_de() {
-    let s = "(foo:1,bar:2,)";
+    let s = "(foo:1,bar:2)";
     let e = EnumStructUntagged::VariantB {
         foo: 1,
         bar: 2,

--- a/tests/93_depth_limit_unresolved.rs
+++ b/tests/93_depth_limit_unresolved.rs
@@ -1,0 +1,12 @@
+// Addresses unresolved questions of PR #93
+// TODO(torkleyy): only question 1 is resolved, 2 is not yet resolved
+
+use ron::ser::{to_string, to_string_pretty, PrettyConfig};
+
+#[test]
+fn omit_trailing_comma_non_pretty() {
+    let x = vec![vec![1u32, 2, 3], vec![4, 5, 6]];
+
+    let s = to_string(&x).unwrap();
+    assert_eq!(s, "[[1,2,3],[4,5,6]]");
+}

--- a/tests/93_depth_limit_unresolved.rs
+++ b/tests/93_depth_limit_unresolved.rs
@@ -1,7 +1,7 @@
 // Addresses unresolved questions of PR #93
 // TODO(torkleyy): only question 1 is resolved, 2 is not yet resolved
 
-use ron::ser::{to_string, to_string_pretty, PrettyConfig};
+use ron::ser::to_string;
 
 #[test]
 fn omit_trailing_comma_non_pretty() {

--- a/tests/depth_limit.rs
+++ b/tests/depth_limit.rs
@@ -26,12 +26,12 @@ struct Nested {
 }
 
 const EXPECTED: &str = "(
-    float: (2.18,-1.1,),
-    tuple: ((),false,),
-    map: {8:'1',},
-    nested: (a:\"a\",b:'b',),
-    var: A(255,\"\",),
-    array: [(),(),(),],
+    float: (2.18,-1.1),
+    tuple: ((),false),
+    map: {8:'1'},
+    nested: (a:\"a\",b:'b'),
+    var: A(255,\"\"),
+    array: [(),(),()],
 )";
 
 #[test]


### PR DESCRIPTION
This partially addresses #94; I will cover the other part of it (spaces between elements) after the serializer refactor (#175).

Closes #94