### PR TITLE
Use the radix64 crate for base64 encoding/decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["bors.toml", ".travis.yml"]
 name = "ron"
 
 [dependencies]
-base64 = "0.10"
+radix64 = "0.6"
 bitflags = "1"
 indexmap = { version = "1.0.2", features = ["serde-1"], optional = true }
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParseError {
-    Base64Error(base64::DecodeError),
+    Base64Error(radix64::DecodeError),
     Eof,
     ExpectedArray,
     ExpectedArrayEnd,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -290,13 +290,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        use radix64::STD as base64;
         let res = {
             let string = self.bytes.string()?;
             let base64_str = match string {
                 ParsedStr::Allocated(ref s) => s.as_str(),
                 ParsedStr::Slice(ref s) => s,
             };
-            base64::decode(base64_str)
+            base64.decode(base64_str)
         };
 
         match res {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -386,7 +386,8 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        self.serialize_str(base64::encode(v).as_str())
+        use radix64::STD as base64;
+        self.serialize_str(base64.encode(v).as_str())
     }
 
     fn serialize_none(self) -> Result<()> {


### PR DESCRIPTION
Cards on the table: I'm the author of radix64.

I noticed that ron uses base64 to serialize bytes. I created a new base64 encoding and decoding library that is faster than the base64 crate (especially when dealing with large inputs) and thought that ron would be a perfect place to use it. You can see that the api is pretty similar to what base64 offers. This would be a breaking change for users since the type of DecodeError exposed in ParseError will change, but otherwise I think it's a net positive. Let me know if you have any concerns, I understand accepting a new dependency (especially one that's self promoted like this) can make people nervous.