### PR TITLE
Cargo version up Added Ryu crate to handle f32 and f64 serializing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ron"
-version = "0.6.0"
+version = "0.5.3"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ron"
-version = "0.5.2"
+version = "0.6.0"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [
@@ -24,6 +24,7 @@ base64 = "0.10"
 bitflags = "1"
 indexmap = { version = "1.0.2", features = ["serde-1"], optional = true }
 serde = { version = "1", features = ["serde_derive"] }
+ryu = "1.0.0"
 
 [dev-dependencies]
 serde_bytes = "0.11"

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -42,6 +42,8 @@ fn test_struct() {
 
     assert_eq!(Ok(my_struct), from_str("MyStruct(x:4,y:7,)"));
     assert_eq!(Ok(my_struct), from_str("(x:4,y:7)"));
+    assert_eq!(Ok(my_struct), from_bytes(b"(x:4,y:7)"));
+
 
     #[derive(Debug, PartialEq, Deserialize)]
     struct NewType(i32);

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -21,12 +21,37 @@ where
     Ok(s.output)
 }
 
+/// Serializes `value` and returns it as string with including the structure
+/// name.
+///
+/// This function does not generate any newlines or nice formatting;
+/// if you want that, you can use `to_string_pretty` instead.
+pub fn to_string_with_name<T>(value: &T) -> Result<String>
+where
+    T: Serialize,
+{
+    let mut s = Serializer::new(None, true);
+    value.serialize(&mut s)?;
+    Ok(s.output)
+}
+
 /// Serializes `value` in the recommended RON layout in a pretty way.
 pub fn to_string_pretty<T>(value: &T, config: PrettyConfig) -> Result<String>
 where
     T: Serialize,
 {
     let mut s = Serializer::new(Some(config), false);
+    value.serialize(&mut s)?;
+    Ok(s.output)
+}
+
+/// Serializes `value` in the recommended RON layout in a pretty way including
+/// the structure name.
+pub fn to_string_with_name_pretty<T>(value: &T, config: PrettyConfig) -> Result<String>
+where
+    T: Serialize,
+{
+    let mut s = Serializer::new(Some(config), true);
     value.serialize(&mut s)?;
     Ok(s.output)
 }
@@ -112,8 +137,9 @@ impl PrettyConfig {
     }
 
     /// Limits the pretty-formatting based on the number of indentations.
-    /// I.e., with a depth limit of 5, starting with an element of depth (indentation level) 6,
-    /// everything will be put into the same line, without pretty formatting.
+    /// I.e., with a depth limit of 5, starting with an element of depth
+    /// (indentation level) 6, everything will be put into the same line,
+    /// without pretty formatting.
     ///
     /// Default: [std::usize::MAX]
     pub fn with_depth_limit(mut self, depth_limit: usize) -> Self {
@@ -141,8 +167,9 @@ impl PrettyConfig {
     }
 
     /// Configures whether tuples are single- or multi-line.
-    /// If set to `true`, tuples will have their fields indented and in new lines.
-    /// If set to `false`, tuples will be serialized without any newlines or indentations.
+    /// If set to `true`, tuples will have their fields indented and in new
+    /// lines. If set to `false`, tuples will be serialized without any
+    /// newlines or indentations.
     ///
     /// Default: `false`
     pub fn with_separate_tuple_members(mut self, separate_tuple_members: bool) -> Self {
@@ -151,8 +178,8 @@ impl PrettyConfig {
         self
     }
 
-    /// Configures whether a comment shall be added to every array element, indicating
-    /// the index.
+    /// Configures whether a comment shall be added to every array element,
+    /// indicating the index.
     ///
     /// Default: `false`
     pub fn with_enumerate_arrays(mut self, enumerate_arrays: bool) -> Self {
@@ -373,12 +400,14 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        self.output += &v.to_string();
+        let mut buffer = ryu::Buffer::new();
+        self.output += buffer.format(v);
         Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        self.output += &v.to_string();
+        let mut buffer = ryu::Buffer::new();
+        self.output += buffer.format(v);
         Ok(())
     }
 


### PR DESCRIPTION
Chose to version up the crate to 0.6 since changes to serialize_f32 and serialize_f64 were made using Ryu rather than to_string() method.

serde_json uses Ryu, to stringify float values just an FYI.

The reasoning behind this change because to_string will strip the decimals from the value if given a whole value.
example being 1.0f32.to_string() will become "1" the correct result should have been "1.0"

This leads to an issue when deserializing the data back to its original type.

Additionally added 2 new `to_string` methods that includes the struct name.

other changes are result of Rustfmt