### PR TITLE
Integer support

### DIFF
--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -53,7 +53,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: Error,
     {
-        self.visit_i128(v as i128)
+        Ok(Value::Number(Number::new(v)))
     }
 
     fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
@@ -67,7 +67,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: Error,
     {
-        self.visit_u128(v as u128)
+        Ok(Value::Number(Number::new(v)))
     }
 
     fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
@@ -205,9 +205,9 @@ mod tests {
     #[test]
     fn test_tuples_basic() {
         assert_eq!(
-            eval("(3, 4, 5)"),
+            eval("(3, 4.0, 5.0)"),
             Value::Seq(vec![
-                Value::Number(Number::new(3.0)),
+                Value::Number(Number::new(3)),
                 Value::Number(Number::new(4.0)),
                 Value::Number(Number::new(5.0)),
             ],),
@@ -217,11 +217,11 @@ mod tests {
     #[test]
     fn test_tuples_ident() {
         assert_eq!(
-            eval("(true, 3, 4, 5)"),
+            eval("(true, 3, 4, 5.0)"),
             Value::Seq(vec![
                 Value::Bool(true),
-                Value::Number(Number::new(3.0)),
-                Value::Number(Number::new(4.0)),
+                Value::Number(Number::new(3)),
+                Value::Number(Number::new(4)),
                 Value::Number(Number::new(5.0)),
             ]),
         );
@@ -260,8 +260,8 @@ mod tests {
     Room ( width: 20, height: 5, name: \"The Room\" ),
 
     (
-        width: 10,
-        height: 10,
+        width: 10.0,
+        height: 10.0,
         name: \"Another room\",
         enemy_levels: {
             \"Enemy1\": 3,
@@ -276,11 +276,11 @@ mod tests {
                     vec![
                         (
                             Value::String("width".to_owned()),
-                            Value::Number(Number::new(20.0)),
+                            Value::Number(Number::new(20)),
                         ),
                         (
                             Value::String("height".to_owned()),
-                            Value::Number(Number::new(5.0)),
+                            Value::Number(Number::new(5)),
                         ),
                         (
                             Value::String("name".to_owned()),
@@ -310,15 +310,15 @@ mod tests {
                                 vec![
                                     (
                                         Value::String("Enemy1".to_owned()),
-                                        Value::Number(Number::new(3.0)),
+                                        Value::Number(Number::new(3)),
                                     ),
                                     (
                                         Value::String("Enemy2".to_owned()),
-                                        Value::Number(Number::new(5.0)),
+                                        Value::Number(Number::new(5)),
                                     ),
                                     (
                                         Value::String("Enemy3".to_owned()),
-                                        Value::Number(Number::new(7.0)),
+                                        Value::Number(Number::new(7)),
                                     ),
                                 ]
                                 .into_iter()

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -1,6 +1,6 @@
 use serde::ser::{Serialize, Serializer};
 
-use crate::value::Value;
+use crate::value::{Number, Value};
 
 impl Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -11,7 +11,8 @@ impl Serialize for Value {
             Value::Bool(b) => serializer.serialize_bool(b),
             Value::Char(c) => serializer.serialize_char(c),
             Value::Map(ref m) => Serialize::serialize(m, serializer),
-            Value::Number(ref n) => serializer.serialize_f64(n.get()),
+            Value::Number(Number::Float(ref f)) => serializer.serialize_f64(f.get()),
+            Value::Number(Number::Integer(i)) => serializer.serialize_i64(i),
             Value::Option(Some(ref o)) => serializer.serialize_some(o.as_ref()),
             Value::Option(None) => serializer.serialize_none(),
             Value::String(ref s) => serializer.serialize_str(s),

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -15,14 +15,14 @@ fn char() {
 #[test]
 fn map() {
     let mut map = Map::new();
-    map.insert(Value::Char('a'), Value::Number(Number::new(1f64)));
+    map.insert(Value::Char('a'), Value::Number(Number::new(1)));
     map.insert(Value::Char('b'), Value::Number(Number::new(2f64)));
-    assert_eq!("{ 'a': 1, 'b': 2 }".parse(), Ok(Value::Map(map)));
+    assert_eq!("{ 'a': 1, 'b': 2.0 }".parse(), Ok(Value::Map(map)));
 }
 
 #[test]
 fn number() {
-    assert_eq!("42".parse(), Ok(Value::Number(Number::new(42f64))));
+    assert_eq!("42".parse(), Ok(Value::Number(Number::new(42))));
     assert_eq!("3.1415".parse(), Ok(Value::Number(Number::new(3.1415f64))));
 }
 
@@ -59,10 +59,10 @@ fn string() {
 #[test]
 fn seq() {
     let seq = vec![
-        Value::Number(Number::new(1f64)),
+        Value::Number(Number::new(1)),
         Value::Number(Number::new(2f64)),
     ];
-    assert_eq!("[1, 2]".parse(), Ok(Value::Seq(seq)));
+    assert_eq!("[1, 2.0]".parse(), Ok(Value::Seq(seq)));
 }
 
 #[test]


### PR DESCRIPTION
Roughly following the discussion from https://github.com/ron-rs/ron/issues/47 and related issues and PRs, this PR extends the Number type (and so indirectly the Value type) to support integers. I hope I didn't grossly misunderstand the discussion there, but I am keen to make adjustments here to make the project better.

~~I tried to limit the impact to the API to a single breaking change by extending the already opaque `Number` type rather than the `Value` enum which exposes its structure. The breaking change is that the `get` method in `Number` is replaced by `as_f64` and `as_i64` for getting the appropriate type.~~
Since `Integer` and `Float` types are distinct, they will not be ordered by value (as explained below). This is a breaking change in itself.

To maintain the traits on `Number`, `Integer`s are simply ordered before `Float`s. This makes float and integer not comparable in value (e.g. `Number::Integer(2)` < `Number::Float(Float(1.0))`) because I didn't see any necessity to do so, but I'm open to suggestions.

The tests are adjusted to verify that both integers and floats are working.