### PR TITLE
Add clippy to CI + address clippy problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ cache: cargo
 script:
   - cargo test
   - cargo test --all-features
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,15 @@ branches:
 
 matrix:
   allow_failures:
-    - name: "Clippy"
+    - name: "Clippy: stable"
   include:
     - rust: stable
+      name: "Format: stable"
       script:
         - rustup component add rustfmt
         - cargo fmt -- --check
     - rust: stable
-      name: "Clippy"
+      name: "Clippy: stable"
       script:
         - rustup component add clippy
         - cargo clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,18 @@ branches:
     - master
 
 matrix:
+  allow_failures:
+    - name: "Clippy"
   include:
     - rust: stable
       script:
         - rustup component add rustfmt
         - cargo fmt -- --check
+    - rust: stable
+      name: "Clippy"
+      script:
+        - rustup component add clippy
+        - cargo clippy
 
 cache: cargo
 

--- a/examples/transcode.rs
+++ b/examples/transcode.rs
@@ -25,7 +25,7 @@ fn main() {
         )
         "#;
 
-    let value = Value::from_str(data).expect("Failed to deserialize");
+    let value: Value = data.parse().expect("Failed to deserialize");
     let mut ser = serde_json::Serializer::pretty(std::io::stdout());
     value.serialize(&mut ser).expect("Failed to serialize");
 }

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -10,9 +10,11 @@ use crate::{
     value::{Map, Number, Value},
 };
 
-impl Value {
+impl std::str::FromStr for Value {
+    type Err = de::Error;
+
     /// Creates a value from a string reference.
-    pub fn from_str(s: &str) -> de::Result<Self> {
+    fn from_str(s: &str) -> de::Result<Self> {
         let mut de = super::Deserializer::from_str(s)?;
 
         let val = Value::deserialize(&mut de)?;

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -168,9 +168,10 @@ impl<'de> Visitor<'de> for ValueVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     fn eval(s: &str) -> Value {
-        Value::from_str(s).expect("Failed to parse")
+        s.parse().expect("Failed to parse")
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -381,7 +381,8 @@ impl<'a> Bytes<'a> {
     }
 
     pub fn expect_byte(&mut self, byte: u8, error: ParseError) -> Result<()> {
-        self.eat_byte().and_then(|b| if b == byte { Ok(()) } else { self.err(error) })
+        self.eat_byte()
+            .and_then(|b| if b == byte { Ok(()) } else { self.err(error) })
     }
 
     /// Returns the extensions bit mask.

--- a/src/value.rs
+++ b/src/value.rs
@@ -153,10 +153,7 @@ impl Number {
 /// underlying `f64` values itself.
 impl PartialEq for Number {
     fn eq(&self, other: &Self) -> bool {
-        if self.0.is_nan() && other.0.is_nan() {
-            return true;
-        }
-        return self.0 == other.0;
+        self.0.is_nan() && other.0.is_nan() || self.0 == other.0
     }
 }
 

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -3,13 +3,13 @@ use serde::Serialize;
 
 #[test]
 fn bool() {
-    assert_eq!(Value::from_str("true"), Ok(Value::Bool(true)));
-    assert_eq!(Value::from_str("false"), Ok(Value::Bool(false)));
+    assert_eq!("true".parse(), Ok(Value::Bool(true)));
+    assert_eq!("false".parse(), Ok(Value::Bool(false)));
 }
 
 #[test]
 fn char() {
-    assert_eq!(Value::from_str("'a'"), Ok(Value::Char('a')));
+    assert_eq!("'a'".parse(), Ok(Value::Char('a')));
 }
 
 #[test]
@@ -17,14 +17,14 @@ fn map() {
     let mut map = Map::new();
     map.insert(Value::Char('a'), Value::Number(Number::new(1f64)));
     map.insert(Value::Char('b'), Value::Number(Number::new(2f64)));
-    assert_eq!(Value::from_str("{ 'a': 1, 'b': 2 }"), Ok(Value::Map(map)));
+    assert_eq!("{ 'a': 1, 'b': 2 }".parse(), Ok(Value::Map(map)));
 }
 
 #[test]
 fn number() {
-    assert_eq!(Value::from_str("42"), Ok(Value::Number(Number::new(42f64))));
+    assert_eq!("42".parse(), Ok(Value::Number(Number::new(42f64))));
     assert_eq!(
-        Value::from_str("3.1415"),
+        "3.1415".parse(),
         Ok(Value::Number(Number::new(3.1415f64)))
     );
 }
@@ -32,32 +32,32 @@ fn number() {
 #[test]
 fn option() {
     let opt = Some(Box::new(Value::Char('c')));
-    assert_eq!(Value::from_str("Some('c')"), Ok(Value::Option(opt)));
+    assert_eq!("Some('c')".parse(), Ok(Value::Option(opt)));
 }
 
 #[test]
 fn string() {
     let normal = "\"String\"";
-    assert_eq!(Value::from_str(normal), Ok(Value::String("String".into())));
+    assert_eq!(normal.parse(), Ok(Value::String("String".into())));
 
     let raw = "r\"Raw String\"";
-    assert_eq!(Value::from_str(raw), Ok(Value::String("Raw String".into())));
+    assert_eq!(raw.parse(), Ok(Value::String("Raw String".into())));
 
     let raw_hashes = "r#\"Raw String\"#";
     assert_eq!(
-        Value::from_str(raw_hashes),
+        raw_hashes.parse(),
         Ok(Value::String("Raw String".into()))
     );
 
     let raw_escaped = "r##\"Contains \"#\"##";
     assert_eq!(
-        Value::from_str(raw_escaped),
+        raw_escaped.parse(),
         Ok(Value::String("Contains \"#".into()))
     );
 
     let raw_multi_line = "r\"Multi\nLine\"";
     assert_eq!(
-        Value::from_str(raw_multi_line),
+        raw_multi_line.parse(),
         Ok(Value::String("Multi\nLine".into()))
     );
 }
@@ -68,18 +68,18 @@ fn seq() {
         Value::Number(Number::new(1f64)),
         Value::Number(Number::new(2f64)),
     ];
-    assert_eq!(Value::from_str("[1, 2]"), Ok(Value::Seq(seq)));
+    assert_eq!("[1, 2]".parse(), Ok(Value::Seq(seq)));
 }
 
 #[test]
 fn unit() {
     use ron::de::{Error, ParseError, Position};
 
-    assert_eq!(Value::from_str("()"), Ok(Value::Unit));
-    assert_eq!(Value::from_str("Foo"), Ok(Value::Unit));
+    assert_eq!("()".parse(), Ok(Value::Unit));
+    assert_eq!("Foo".parse(), Ok(Value::Unit));
 
     assert_eq!(
-        Value::from_str(""),
+        "".parse::<Value>(),
         Err(Error::Parser(ParseError::Eof, Position { col: 1, line: 1 }))
     );
 }

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -23,10 +23,7 @@ fn map() {
 #[test]
 fn number() {
     assert_eq!("42".parse(), Ok(Value::Number(Number::new(42f64))));
-    assert_eq!(
-        "3.1415".parse(),
-        Ok(Value::Number(Number::new(3.1415f64)))
-    );
+    assert_eq!("3.1415".parse(), Ok(Value::Number(Number::new(3.1415f64))));
 }
 
 #[test]
@@ -44,10 +41,7 @@ fn string() {
     assert_eq!(raw.parse(), Ok(Value::String("Raw String".into())));
 
     let raw_hashes = "r#\"Raw String\"#";
-    assert_eq!(
-        raw_hashes.parse(),
-        Ok(Value::String("Raw String".into()))
-    );
+    assert_eq!(raw_hashes.parse(), Ok(Value::String("Raw String".into())));
 
     let raw_escaped = "r##\"Contains \"#\"##";
     assert_eq!(


### PR DESCRIPTION
This commit
1. Adds `cargo clippy` to .travis.yml that is allowed to fail to reduce friction for incoming PRs.
2. Addresses clippy concerns and clarifies places where they should be ignored.

Addresses half of #211