### PR TITLE
Fix parsing of borrowed strings

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -271,7 +271,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match self.bytes.string()? {
             ParsedStr::Allocated(s) => visitor.visit_string(s),
-            ParsedStr::Slice(s) => visitor.visit_str(s),
+            ParsedStr::Slice(s) => visitor.visit_borrowed_str(s),
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -556,7 +556,7 @@ impl<'a> Bytes<'a> {
         }
     }
 
-    pub fn string(&mut self) -> Result<ParsedStr<'_>> {
+    pub fn string(&mut self) -> Result<ParsedStr<'a>> {
         if self.consume("\"") {
             self.escaped_string()
         } else if self.consume("r") {
@@ -566,7 +566,7 @@ impl<'a> Bytes<'a> {
         }
     }
 
-    fn escaped_string(&mut self) -> Result<ParsedStr<'_>> {
+    fn escaped_string(&mut self) -> Result<ParsedStr<'a>> {
         use std::iter::repeat;
 
         let (i, end_or_escape) = self
@@ -621,7 +621,7 @@ impl<'a> Bytes<'a> {
         }
     }
 
-    fn raw_string(&mut self) -> Result<ParsedStr<'_>> {
+    fn raw_string(&mut self) -> Result<ParsedStr<'a>> {
         let num_hashes = self.bytes.iter().take_while(|&&b| b == b'#').count();
         let hashes = &self.bytes[..num_hashes];
         let _ = self.advance(num_hashes);

--- a/tests/borrowed_str.rs
+++ b/tests/borrowed_str.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Borrowed<'a> {
+    value: &'a str,
+}
+
+const BORROWED: &str = "Borrowed(value: \"test\")";
+
+#[test]
+fn borrowed_str() {
+    assert_eq!(
+        ron::de::from_str(BORROWED).ok(),
+        Some(Borrowed { value: "test" })
+    );
+}


### PR DESCRIPTION
The implementation of `deserialize_str` would incorrectly call `Visitor::visit_str` when it should have called `Visitor::visit_borrowed_str`. As per https://serde.rs/lifetimes.html#transient-borrowed-and-owned-data, `visit_borrowed_str` should be called when the lifetime of the deserialized string is that of the input.

This should not be a breaking change, because it only extends the lifetime of the deserialized string. The default implementation of `Visitor::visit_borrowed_str` forwards to `visit_str`, meaning that this commit only enables more flexibility.

I added a test in `tests/borrowed_str.rs` which demonstrates this behavior. Prior to this change, the test would fail.