### PR TITLE
Remove #[non-exhaustive] for compatiblity back to rust 1.34.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [stable, nightly]
+        rust: [1.34.0, stable, nightly]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,6 @@ pub struct Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ErrorCode {
     Io(String),
@@ -55,6 +54,9 @@ pub enum ErrorCode {
 
     Utf8Error(Utf8Error),
     TrailingCharacters,
+
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl fmt::Display for Error {
@@ -106,6 +108,7 @@ impl fmt::Display for ErrorCode {
             ErrorCode::UnderscoreAtBeginning => f.write_str("Found underscore at the beginning"),
             ErrorCode::UnexpectedByte(_) => f.write_str("Unexpected byte"),
             ErrorCode::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
+            _ => f.write_str("Unknown ErrorCode"),
         }
     }
 }


### PR DESCRIPTION
(Which is the version in Debian stable and many other distros).

Otherwise the minimum supported Rust version is 1.40.0

While here, add a CI job that tests Rust 1.34.0 builds too