### PR TITLE
Enable external crates to link to the doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ron"
+# Memo: update version in src/lib.rs too (doc link)
 version = "0.5.2"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ Serializing / Deserializing is as simple as calling `to_string` / `from_str`.
 
 !*/
 
-#![doc(html_root_url = "https://docs.rs/ron/5.1")]
+#![doc(html_root_url = "https://docs.rs/ron/0.5.1")]
 
 pub mod de;
 pub mod ser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ Serializing / Deserializing is as simple as calling `to_string` / `from_str`.
 
 !*/
 
+#![doc(html_root_url = "https://docs.rs/ron/5.1")]
+
 pub mod de;
 pub mod ser;
 


### PR DESCRIPTION
Enable external crates to reference `ron`'s types in their documentation.

Note that it should be updated with each new version.