### PR TITLE
Optionally always include float decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Next
+- Added `decimal_floats` PrettyConfig option, which always includes decimals in floats (`1.0` vs `1`) ([#237](https://github.com/ron-rs/ron/pull/237))
 
 ## [0.6.0] - 2020-05-21
 ### Additions

--- a/tests/floats.rs
+++ b/tests/floats.rs
@@ -1,8 +1,30 @@
-use ron::de::from_str;
+use ron::{
+    de::from_str,
+    ser::{to_string_pretty, PrettyConfig},
+};
 
 #[test]
 fn test_inf_and_nan() {
     assert_eq!(from_str("inf"), Ok(std::f64::INFINITY));
     assert_eq!(from_str("-inf"), Ok(std::f64::NEG_INFINITY));
     assert_eq!(from_str::<f64>("NaN").map(|n| n.is_nan()), Ok(true))
+}
+
+#[test]
+fn decimal_floats() {
+    let pretty = PrettyConfig::new().with_decimal_floats(false);
+    let without_decimal = to_string_pretty(&1.0, pretty).unwrap();
+    assert_eq!(without_decimal, "1");
+
+    let pretty = PrettyConfig::new().with_decimal_floats(false);
+    let without_decimal = to_string_pretty(&1.1, pretty).unwrap();
+    assert_eq!(without_decimal, "1.1");
+
+    let pretty = PrettyConfig::new().with_decimal_floats(true);
+    let with_decimal = to_string_pretty(&1.0, pretty).unwrap();
+    assert_eq!(with_decimal, "1.0");
+
+    let pretty = PrettyConfig::new().with_decimal_floats(true);
+    let with_decimal = to_string_pretty(&1.1, pretty).unwrap();
+    assert_eq!(with_decimal, "1.1");
 }


### PR DESCRIPTION
This adds the option to always include the decimal point in floats.

Currently ron always serializes `5.0` as `5`. I have a use case that makes the `5` vs `5.0` distinction important. My rust type is a dynamic collection that can contain either floats or ints. Round tripping a value of `5.0` with ron results in an integer output of `5` when its source was a float.