### PR TITLE
Make untagged enums work

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -105,9 +105,7 @@ impl<'de> Deserializer<'de> {
         let mut bytes = self.bytes;
 
         // The caller checks for a brace before calling this
-        if !bytes.consume("(") {
-            unreachable!();
-        }
+        bytes.advance_single()?;
 
         bytes.skip_ws()?;
 

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -326,3 +326,40 @@ fn test_any_number_precision() {
     assert_eq!(de_any_number("-1."), AnyNum::F32(-1.));
     assert_eq!(de_any_number("0.3"), AnyNum::F64(0.3));
 }
+
+#[test]
+fn test_untagged_enum() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    pub enum UnitType {
+        Explorer,
+    }
+    use UnitType::*;
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    pub enum CardTextNumber {
+        Range(u8),
+        CountUnit(Vec<UnitType>),
+        PowerCardsPlayed,
+    }
+    use CardTextNumber::*;
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    #[serde(untagged)]
+    enum CardTextNumberFlat {
+        JustNum(u8),
+        Fancy(CardTextNumber),
+    }
+    use CardTextNumberFlat::*;
+
+    assert_eq!(from_str("1"), Ok(JustNum(1)));
+    assert_eq!(from_str("Range(1)"), Ok(Fancy(Range(1))));
+    assert_eq!(
+        from_str("CountUnit([Explorer])"),
+        Ok(Fancy(CountUnit(vec![Explorer])))
+    );
+    assert_eq!(
+        from_str("CountUnit([Explorer, Explorer])"),
+        Ok(Fancy(CountUnit(vec![Explorer, Explorer])))
+    );
+    assert_eq!(from_str("PowerCardsPlayed"), Ok(Fancy(PowerCardsPlayed)));
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -321,19 +321,6 @@ impl<'a> Bytes<'a> {
             .map_or(false, |b| IDENT_CHAR.contains(b))
     }
 
-    /// Should only be used on a working copy
-    pub fn check_tuple_struct(mut self) -> Result<bool> {
-        if self.identifier().is_err() {
-            // if there's no field ident, this is a tuple struct
-            return Ok(true);
-        }
-
-        self.skip_ws()?;
-
-        // if there is no colon after the ident, this can only be a unit struct
-        self.eat_byte().map(|c| c != b':')
-    }
-
     /// Only returns true if the char after `ident` cannot belong
     /// to an identifier.
     pub fn consume_ident(&mut self, ident: &str) -> bool {


### PR DESCRIPTION
When deserializing an untagged enum, serde uses deserialize_any. There is ambiguity, as we cannot know if a struct or an enum is expected. That ambiguity is resolved by serde if we just give it a JSON-like data structure.

When we encounter an lone identifier, it becomes a string. An identifier with parens after it becomes a singleton map.

Solves #217 

## Newtype pain

`Id(Val)` would be `{"Id": "Val"}` in JSON, but RON produces a one-element tuple instead. The only way to identify that case that I could think of is checking for commas, which unfortunately makes deserializing somewhat quadratic. It could be linear if this was done as a preprocessing pass.

Is there a way to first read a tuple but then change it if it only has one element?

## Failing test case

One of the tests (https://github.com/ron-rs/ron/blob/25aa1eba9bbe39ef777a3d7a1fe2f3c0fb58696d/src/de/value.rs#L256) now fails because it doesn't expect a map. I think it should expect a map, but I don't understand that test's purpose very well, so maybe someone else can comment on this?