### PR TITLE
move PrettyConfig methods into dedicated builder struct

### DIFF
--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -40,9 +40,9 @@ fn main() {
     };
 
     let pretty = PrettyConfig::new()
-        .with_depth_limit(2)
-        .with_separate_tuple_members(true)
-        .with_enumerate_arrays(true);
+        .depth_limit(2)
+        .separate_tuple_members(true)
+        .enumerate_arrays(true);
     let s = to_string_pretty(&data, pretty).expect("Serialization failed");
 
     println!("{}", s);

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -87,9 +87,26 @@ pub struct PrettyConfig {
 }
 
 impl PrettyConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn build() -> PrettyConfigBuilder {
+        PrettyConfigBuilder::new()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PrettyConfigBuilder {
+    inner: PrettyConfig,
+}
+
+impl PrettyConfigBuilder {
     /// Creates a default `PrettyConfig`.
     pub fn new() -> Self {
-        Default::default()
+        Self {
+            inner: PrettyConfig::new(),
+        }
     }
 
     /// Limits the pretty-formatting based on the number of indentations.
@@ -98,8 +115,8 @@ impl PrettyConfig {
     /// without pretty formatting.
     ///
     /// Default: [std::usize::MAX]
-    pub fn depth_limit(mut self, depth_limit: usize) -> Self {
-        self.depth_limit = depth_limit;
+    pub fn depth_limit(&mut self, depth_limit: usize) -> &mut Self {
+        self.inner.depth_limit = depth_limit;
 
         self
     }
@@ -107,8 +124,8 @@ impl PrettyConfig {
     /// Configures the newlines used for serialization.
     ///
     /// Default: `\r\n` on Windows, `\n` otherwise
-    pub fn new_line(mut self, new_line: String) -> Self {
-        self.new_line = new_line;
+    pub fn new_line(&mut self, new_line: String) -> &mut Self {
+        self.inner.new_line = new_line;
 
         self
     }
@@ -116,8 +133,8 @@ impl PrettyConfig {
     /// Configures the string sequence used for indentation.
     ///
     /// Default: 4 spaces
-    pub fn indentor(mut self, indentor: String) -> Self {
-        self.indentor = indentor;
+    pub fn indentor(&mut self, indentor: String) -> &mut Self {
+        self.inner.indentor = indentor;
 
         self
     }
@@ -128,8 +145,8 @@ impl PrettyConfig {
     /// newlines or indentations.
     ///
     /// Default: `false`
-    pub fn separate_tuple_members(mut self, separate_tuple_members: bool) -> Self {
-        self.separate_tuple_members = separate_tuple_members;
+    pub fn separate_tuple_members(&mut self, separate_tuple_members: bool) -> &mut Self {
+        self.inner.separate_tuple_members = separate_tuple_members;
 
         self
     }
@@ -138,8 +155,8 @@ impl PrettyConfig {
     /// indicating the index.
     ///
     /// Default: `false`
-    pub fn enumerate_arrays(mut self, enumerate_arrays: bool) -> Self {
-        self.enumerate_arrays = enumerate_arrays;
+    pub fn enumerate_arrays(&mut self, enumerate_arrays: bool) -> &mut Self {
+        self.inner.enumerate_arrays = enumerate_arrays;
 
         self
     }
@@ -149,8 +166,8 @@ impl PrettyConfig {
     /// When true `1.0` will serialize as `1.0`
     ///
     /// Default: `false`
-    pub fn decimal_floats(mut self, decimal_floats: bool) -> Self {
-        self.decimal_floats = decimal_floats;
+    pub fn decimal_floats(&mut self, decimal_floats: bool) -> &mut Self {
+        self.inner.decimal_floats = decimal_floats;
 
         self
     }
@@ -158,10 +175,15 @@ impl PrettyConfig {
     /// Configures extensions
     ///
     /// Default: Extensions::empty()
-    pub fn extensions(mut self, extensions: Extensions) -> Self {
-        self.extensions = extensions;
+    pub fn extensions(&mut self, extensions: Extensions) -> &mut Self {
+        self.inner.extensions = extensions;
 
         self
+    }
+
+    /// Returns the build `PrettyConfig`.
+    pub fn build(self) -> PrettyConfig {
+        self.inner
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -55,9 +55,9 @@ struct Pretty {
 /// use ron::ser::PrettyConfig;
 ///
 /// let my_config = PrettyConfig::new()
-///     .with_depth_limit(4)
+///     .depth_limit(4)
 ///     // definitely superior (okay, just joking)
-///     .with_indentor("\t".to_owned());
+///     .indentor("\t".to_owned());
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PrettyConfig {
@@ -98,7 +98,7 @@ impl PrettyConfig {
     /// without pretty formatting.
     ///
     /// Default: [std::usize::MAX]
-    pub fn with_depth_limit(mut self, depth_limit: usize) -> Self {
+    pub fn depth_limit(mut self, depth_limit: usize) -> Self {
         self.depth_limit = depth_limit;
 
         self
@@ -107,7 +107,7 @@ impl PrettyConfig {
     /// Configures the newlines used for serialization.
     ///
     /// Default: `\r\n` on Windows, `\n` otherwise
-    pub fn with_new_line(mut self, new_line: String) -> Self {
+    pub fn new_line(mut self, new_line: String) -> Self {
         self.new_line = new_line;
 
         self
@@ -116,7 +116,7 @@ impl PrettyConfig {
     /// Configures the string sequence used for indentation.
     ///
     /// Default: 4 spaces
-    pub fn with_indentor(mut self, indentor: String) -> Self {
+    pub fn indentor(mut self, indentor: String) -> Self {
         self.indentor = indentor;
 
         self
@@ -128,7 +128,7 @@ impl PrettyConfig {
     /// newlines or indentations.
     ///
     /// Default: `false`
-    pub fn with_separate_tuple_members(mut self, separate_tuple_members: bool) -> Self {
+    pub fn separate_tuple_members(mut self, separate_tuple_members: bool) -> Self {
         self.separate_tuple_members = separate_tuple_members;
 
         self
@@ -138,7 +138,7 @@ impl PrettyConfig {
     /// indicating the index.
     ///
     /// Default: `false`
-    pub fn with_enumerate_arrays(mut self, enumerate_arrays: bool) -> Self {
+    pub fn enumerate_arrays(mut self, enumerate_arrays: bool) -> Self {
         self.enumerate_arrays = enumerate_arrays;
 
         self
@@ -149,7 +149,7 @@ impl PrettyConfig {
     /// When true `1.0` will serialize as `1.0`
     ///
     /// Default: `false`
-    pub fn with_decimal_floats(mut self, decimal_floats: bool) -> Self {
+    pub fn decimal_floats(mut self, decimal_floats: bool) -> Self {
         self.decimal_floats = decimal_floats;
 
         self
@@ -158,7 +158,7 @@ impl PrettyConfig {
     /// Configures extensions
     ///
     /// Default: Extensions::empty()
-    pub fn with_extensions(mut self, extensions: Extensions) -> Self {
+    pub fn extensions(mut self, extensions: Extensions) -> Self {
         self.extensions = extensions;
 
         self

--- a/tests/147_empty_sets_serialisation.rs
+++ b/tests/147_empty_sets_serialisation.rs
@@ -42,8 +42,8 @@ fn empty_sets_arrays() {
     };
 
     let pretty = ron::ser::PrettyConfig::new()
-        .with_enumerate_arrays(true)
-        .with_new_line("\n".to_string());
+        .enumerate_arrays(true)
+        .new_line("\n".to_string());
     let serial = ron::ser::to_string_pretty(&value, pretty).unwrap();
 
     println!("Serialized: {}", serial);

--- a/tests/240_array_pretty.rs
+++ b/tests/240_array_pretty.rs
@@ -4,7 +4,7 @@ use ron::ser::{to_string_pretty, PrettyConfig};
 fn small_array() {
     let arr = &[(), (), ()][..];
     assert_eq!(
-        to_string_pretty(&arr, PrettyConfig::new().with_new_line("\n".to_string())).unwrap(),
+        to_string_pretty(&arr, PrettyConfig::new().new_line("\n".to_string())).unwrap(),
         "[
     (),
     (),

--- a/tests/depth_limit.rs
+++ b/tests/depth_limit.rs
@@ -49,10 +49,10 @@ fn depth_limit() {
     };
 
     let pretty = ron::ser::PrettyConfig::new()
-        .with_depth_limit(1)
-        .with_separate_tuple_members(true)
-        .with_enumerate_arrays(true)
-        .with_new_line("\n".to_string());
+        .depth_limit(1)
+        .separate_tuple_members(true)
+        .enumerate_arrays(true)
+        .new_line("\n".to_string());
     let s = ron::ser::to_string_pretty(&data, pretty);
 
     assert_eq!(s, Ok(EXPECTED.to_string()));

--- a/tests/floats.rs
+++ b/tests/floats.rs
@@ -12,19 +12,19 @@ fn test_inf_and_nan() {
 
 #[test]
 fn decimal_floats() {
-    let pretty = PrettyConfig::new().with_decimal_floats(false);
+    let pretty = PrettyConfig::new().decimal_floats(false);
     let without_decimal = to_string_pretty(&1.0, pretty).unwrap();
     assert_eq!(without_decimal, "1");
 
-    let pretty = PrettyConfig::new().with_decimal_floats(false);
+    let pretty = PrettyConfig::new().decimal_floats(false);
     let without_decimal = to_string_pretty(&1.1, pretty).unwrap();
     assert_eq!(without_decimal, "1.1");
 
-    let pretty = PrettyConfig::new().with_decimal_floats(true);
+    let pretty = PrettyConfig::new().decimal_floats(true);
     let with_decimal = to_string_pretty(&1.0, pretty).unwrap();
     assert_eq!(with_decimal, "1.0");
 
-    let pretty = PrettyConfig::new().with_decimal_floats(true);
+    let pretty = PrettyConfig::new().decimal_floats(true);
     let with_decimal = to_string_pretty(&1.1, pretty).unwrap();
     assert_eq!(with_decimal, "1.1");
 }

--- a/tests/preserve_sequence.rs
+++ b/tests/preserve_sequence.rs
@@ -33,10 +33,10 @@ fn make_roundtrip(source: &str) -> String {
         }
     };
     let pretty = PrettyConfig::new()
-        .with_depth_limit(3)
-        .with_separate_tuple_members(true)
-        .with_enumerate_arrays(true)
-        .with_new_line("\n".into());
+        .depth_limit(3)
+        .separate_tuple_members(true)
+        .enumerate_arrays(true)
+        .new_line("\n".into());
     to_string_pretty(&config, pretty).expect("Serialization failed")
 }
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -69,8 +69,8 @@ fn roundtrip_pretty() {
     };
 
     let pretty = ron::ser::PrettyConfig::new()
-        .with_enumerate_arrays(true)
-        .with_extensions(Extensions::IMPLICIT_SOME);
+        .enumerate_arrays(true)
+        .extensions(Extensions::IMPLICIT_SOME);
     let serial = ron::ser::to_string_pretty(&value, pretty).unwrap();
 
     println!("Serialized: {}", serial);
@@ -110,7 +110,7 @@ fn roundtrip_sep_tuple_members() {
 
     let value = Both { a, b };
 
-    let pretty = ron::ser::PrettyConfig::new().with_separate_tuple_members(true);
+    let pretty = ron::ser::PrettyConfig::new().separate_tuple_members(true);
     let serial = ron::ser::to_string_pretty(&value, pretty).unwrap();
 
     println!("Serialized: {}", serial);


### PR DESCRIPTION
This PR is a follow-up of #258. It moves the construction of a `PrettyConfig` instance into its own `PrettyConfigBuilder` struct, matching the same idea behind #249.

This is more if a place to discuss this further than a real PR. Tests aren't ported over, I just wanted to convey the idea behind it :) It's based upon #258 to already contain the correct method names.

__Edit:__ From my point-of-view:

- Pro:
  - More idiomic. The current `PrettyConfig` is definitely a builder pattern and this conveys it more explicitly.
  - Uses `&mut self`, allowing to pass the builder by reference to other methods if needed.
- Cons:
  - The earlier approach is fine as well. Works without problems.
  - One more method call (`build()`).
  
Pretty obvious, but this would be a breaking change :)