### PR TITLE
Apply formatting fix to published crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Next
 
+## [0.6.1] - 2020-07-14
+
+### Fixes
+- Fix array formatting regression ([#260](https://github.com/ron-rs/ron/pull/260))
+
 ## [0.6.0] - 2020-05-21
 ### Additions
 - Implement integer support in Numbers ([#210](https://github.com/ron-rs/ron/pull/210))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ron"
 # Memo: update version in src/lib.rs too (doc link)
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -607,22 +607,22 @@ impl<'a, W: io::Write> ser::SerializeSeq for Compound<'a, W> {
                 ser,
             } => {
                 ser.output.write_all(b",")?;
+                if let Some((ref config, ref mut pretty)) = ser.pretty {
+                    if pretty.indent <= config.depth_limit {
+                        if config.enumerate_arrays {
+                            assert!(config.new_line.contains('\n'));
+                            let index = pretty.sequence_index.last_mut().unwrap();
+                            //TODO: when /**/ comments are supported, prepend the index
+                            // to an element instead of appending it.
+                            write!(ser.output, "// [{}]", index).unwrap();
+                            *index += 1;
+                        }
+                        ser.output.write_all(config.new_line.as_bytes())?;
+                    }
+                }
                 ser
             }
         };
-        if let Some((ref config, ref mut pretty)) = ser.pretty {
-            if pretty.indent <= config.depth_limit {
-                if config.enumerate_arrays {
-                    assert!(config.new_line.contains('\n'));
-                    let index = pretty.sequence_index.last_mut().unwrap();
-                    //TODO: when /**/ comments are supported, prepend the index
-                    // to an element instead of appending it.
-                    write!(ser.output, "// [{}]", index).unwrap();
-                    *index += 1;
-                }
-                ser.output.write_all(config.new_line.as_bytes())?;
-            }
-        }
         ser.indent()?;
 
         value.serialize(&mut **ser)?;
@@ -639,6 +639,7 @@ impl<'a, W: io::Write> ser::SerializeSeq for Compound<'a, W> {
                 if let Some((ref config, ref mut pretty)) = ser.pretty {
                     if pretty.indent <= config.depth_limit {
                         ser.output.write_all(b",")?;
+                        ser.output.write_all(config.new_line.as_bytes())?;
                     }
                 }
                 ser

--- a/tests/240_array_pretty.rs
+++ b/tests/240_array_pretty.rs
@@ -1,0 +1,14 @@
+use ron::ser::{to_string_pretty, PrettyConfig};
+
+#[test]
+fn small_array() {
+    let arr = &[(), (), ()][..];
+    assert_eq!(
+        to_string_pretty(&arr, PrettyConfig::new().with_new_line("\n".to_string())).unwrap(),
+        "[
+    (),
+    (),
+    (),
+]"
+    );
+}


### PR DESCRIPTION
This should just be shifting #240 over to the v0.6 branch. Am I doing this right?

Edit: Oh, this fixes #252