### PR TITLE
Change order of line/col fields of `Position`

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -849,8 +849,8 @@ pub enum ParsedStr<'a> {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Position {
-    pub col: usize,
     pub line: usize,
+    pub col: usize,
 }
 
 impl Display for Position {


### PR DESCRIPTION
This makes debug output easier to read: `Position { line: 0, col: 0 }` instead of confusing `Position { col: 0, line: 0 }`. (Note: debug output is used e.g. for `.unwrap`ing)