### PR TITLE
enum_repr extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ serde = { version = "1.0.60", features = ["serde_derive"] }
 [dev-dependencies]
 serde_bytes = "0.11"
 serde_json = "1"
+
+[features]
+enum-repr-extension = []

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -75,7 +75,7 @@ You can add this extension by adding the following attribute at the top of your 
 This feature enables RON to declare unitary enums with numerical representations,
 There are a number of limitations to this feature:
 
-```ron
+```rust
 #[repr(u8)]
 enum Utensils {
   Bowl,
@@ -87,13 +87,23 @@ enum Ingredients {
   Sugar,
   EggWhites
 }
+```
 
+Where the rust portion gets passed to `ron::parse::TypeEnv`
+
+```ron
 Recipe("meringue": [([Whisk, Bowl], [EggWhites, Sugar])])
 ```
+
+From there when you pass the TypeEnv parsed above to `ron::de::with_type_env`.
+You can decode the RON above using the compiled rust:
 
 ```rust
 struct Recipe<String, Vec<(Vec<u8>, Vec<u64>)>>;
 ```
+
+There is some support for prepending the rust code block to the RON code block,
+parsing both from the same string.
 
 Known limitations (Not expected to change):
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -108,9 +108,8 @@ Known limitations (Not expected to change):
 WIP/TODO:
 
 - [x] Proof of concept
-- [ ] Parsing
+- [x] Parsing
 - [ ] [Custom discriminant](https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-fieldless-enumerations)
-- [ ] Deserialization
-- [ ] Feature gate?
- It seems wise to feature gate this, as otherwise it may impact numerical deserialization even with the extension disabled.
+- [x] Deserialization
+- [x] Feature gate (enum-repr-extension)
 - [ ] Serialization?

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -65,3 +65,52 @@ Enabling the feature would automatically infer `Some(x)` if `x` is given. In thi
     value: 5,
 )
 ```
+
+# enum_repr
+
+You can add this extension by adding the following attribute at the top of your RON document:
+
+`#![enable(enum_repr)]`
+
+This feature enables RON to declare unitary enums with numerical representations,
+There are a number of limitations to this feature:
+
+```ron
+#[repr(u8)]
+enum Utensils {
+  Bowl,
+  Whisk
+}
+
+#[repr(u64)]
+enum Ingredients {
+  Sugar,
+  EggWhites
+}
+
+Recipe("meringue": [([Whisk, Bowl], [EggWhites, Sugar])])
+```
+
+```rust
+struct Recipe<String, Vec<(Vec<u8>, Vec<u64>)>>;
+```
+
+Known limitations (Not expected to change):
+
+1. Enum declarations must *only* contain unitary variants.
+  enums with variants such as `Foo(String)` can not be converted into a primitive representation.
+2. Declarations are only supported at the top of the file between enabling of the extension, and values.
+ Once a value has been defined, declaring an enum is a parse error.
+ As such this extension may not be useful for some streaming
+3. Deserialization does not perform type checking between 2 enums of the same representation, or numeric literals[1].
+ This however does not preclude having an external type checker in the future.
+
+WIP/TODO:
+
+- [x] Proof of concept
+- [ ] Parsing
+- [ ] [Custom discriminant](https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-fieldless-enumerations)
+- [ ] Deserialization
+- [ ] Feature gate?
+ It seems wise to feature gate this, as otherwise it may impact numerical deserialization even with the extension disabled.
+- [ ] Serialization?

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -311,7 +311,7 @@ fn test_numbers() {
 }
 
 fn de_any_number(s: &str) -> AnyNum {
-    let mut bytes = Bytes::new(s.as_bytes()).unwrap();
+    let mut bytes = RonParser::new(s.as_bytes(), None).unwrap();
 
     bytes.any_num().unwrap()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,10 @@ pub enum ErrorCode {
     ExpectedStringEnd,
     ExpectedIdentifier,
 
+    DuplicateEnum,
+    DuplicateEnumVariant,
+    NoSuchEnumVariant,
+
     InvalidEscape(&'static str),
 
     IntegerOutOfBounds,
@@ -52,6 +56,7 @@ pub enum ErrorCode {
     UnclosedBlockComment,
     UnderscoreAtBeginning,
     UnexpectedByte(char),
+    UnknownType,
 
     Utf8Error(Utf8Error),
     TrailingCharacters,
@@ -102,6 +107,8 @@ impl fmt::Display for ErrorCode {
             ErrorCode::ExpectedString => f.write_str("Expected string"),
             ErrorCode::ExpectedStringEnd => f.write_str("Expected string end"),
             ErrorCode::ExpectedIdentifier => f.write_str("Expected identifier"),
+            ErrorCode::DuplicateEnum => f.write_str("Duplicated enum name"),
+            ErrorCode::DuplicateEnumVariant => f.write_str("Duplicated enum variant"),
             ErrorCode::InvalidEscape(_) => f.write_str("Invalid escape sequence"),
             ErrorCode::IntegerOutOfBounds => f.write_str("Integer is out of bounds"),
             ErrorCode::NoSuchExtension(_) => f.write_str("No such RON extension"),
@@ -109,6 +116,7 @@ impl fmt::Display for ErrorCode {
             ErrorCode::UnclosedBlockComment => f.write_str("Unclosed block comment"),
             ErrorCode::UnderscoreAtBeginning => f.write_str("Found underscore at the beginning"),
             ErrorCode::UnexpectedByte(_) => f.write_str("Unexpected byte"),
+            ErrorCode::UnknownType => f.write_str("Unknown type"),
             ErrorCode::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
             _ => f.write_str("Unknown ErrorCode"),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,7 @@ pub enum ErrorCode {
     DuplicateEnum,
     DuplicateEnumVariant,
     NoSuchEnumVariant,
+    UnsupportedEnumRepr,
 
     InvalidEscape(&'static str),
 
@@ -56,7 +57,6 @@ pub enum ErrorCode {
     UnclosedBlockComment,
     UnderscoreAtBeginning,
     UnexpectedByte(char),
-    UnknownType,
 
     Utf8Error(Utf8Error),
     TrailingCharacters,
@@ -116,7 +116,7 @@ impl fmt::Display for ErrorCode {
             ErrorCode::UnclosedBlockComment => f.write_str("Unclosed block comment"),
             ErrorCode::UnderscoreAtBeginning => f.write_str("Found underscore at the beginning"),
             ErrorCode::UnexpectedByte(_) => f.write_str("Unexpected byte"),
-            ErrorCode::UnknownType => f.write_str("Unknown type"),
+            ErrorCode::UnsupportedEnumRepr => f.write_str("Unsupported enum repr"),
             ErrorCode::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
             _ => f.write_str("Unknown ErrorCode"),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,7 @@ pub enum ErrorCode {
     ExpectedAttribute,
     ExpectedAttributeEnd,
     ExpectedBoolean,
+    ExpectedBrace,
     ExpectedComma,
     // ExpectedEnum,
     ExpectedChar,
@@ -83,6 +84,7 @@ impl fmt::Display for ErrorCode {
                 f.write_str("Expected closing `)` and `]` after the attribute")
             }
             ErrorCode::ExpectedBoolean => f.write_str("Expected boolean"),
+            ErrorCode::ExpectedBrace => f.write_str("Expected brace"),
             ErrorCode::ExpectedComma => f.write_str("Expected comma"),
             // ErrorCode::ExpectedEnum => f.write_str("Expected enum"),
             ErrorCode::ExpectedChar => f.write_str("Expected char"),

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -5,6 +5,7 @@ bitflags::bitflags! {
     pub struct Extensions: usize {
         const UNWRAP_NEWTYPES = 0x1;
         const IMPLICIT_SOME = 0x2;
+        const ENUM_REPR = 0x3;
     }
 }
 
@@ -14,6 +15,7 @@ impl Extensions {
         match ident {
             b"unwrap_newtypes" => Some(Extensions::UNWRAP_NEWTYPES),
             b"implicit_some" => Some(Extensions::IMPLICIT_SOME),
+            b"enum_repr" => Some(Extensions::ENUM_REPR),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub mod error;
 pub mod value;
 
 pub mod extensions;
+pub use parse::type_env;
 
 pub use de::{from_str, Deserializer};
 pub use error::{Error, Result};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -148,7 +148,6 @@ pub mod type_env {
             Ok(self)
         }
     }
-
 }
 
 use type_env::TypeEnv;

--- a/tests/extensions.rs
+++ b/tests/extensions.rs
@@ -80,7 +80,10 @@ fn implicit_some() {
     println!("implicit_some: {:#?}", d);
 }
 
-const CONFIG_E_R: &str = r##"
+#[cfg(feature = "enum-repr-extension")]
+mod enum_repr {
+    use super::*;
+    const CONFIG_E_R: &str = r##"
 #![enable(enum_repr)]
 
 #[repr(u8)]
@@ -106,21 +109,24 @@ GraphData(
 )
 "##;
 
-#[derive(Debug, Deserialize)]
-struct GraphData {
-    nodes: HashMap<u8, String>,
-    edges: HashMap<String, (u8, u8)>,
-}
+    #[derive(Debug, Deserialize)]
+    struct GraphData {
+        nodes: HashMap<u8, String>,
+        edges: HashMap<String, (u8, u8)>,
+    }
 
-#[test]
-fn enum_repr_deserialize() {
-    let d: GraphData = ron::de::from_str(&CONFIG_E_R).expect("Failed to deserialize");
-    println!("enum_repr {:#?}", d);
-}
+    #[test]
+    fn enum_repr_deserialize() {
+        let d: GraphData = ron::de::from_str(&CONFIG_E_R).expect("Failed to deserialize");
+        println!("enum_repr {:#?}", d);
+    }
 
-#[test]
-fn enum_repr_deserialize_correctly() {
-    let d: GraphData = ron::de::from_str(&CONFIG_E_R).expect("Failed to deserialize");
-    assert_eq!(d.nodes[&0], "foo");
-    assert_eq!(d.edges["foo -> bar"], (0, 1));
+    #[test]
+    fn enum_repr_deserialize_correctly() {
+        let d: GraphData = ron::de::from_str(&CONFIG_E_R).expect("Failed to deserialize");
+        assert_eq!(d.nodes[&0], "foo");
+        assert_eq!(d.edges["foo -> bar"], (0, 1));
+        assert_eq!(d.edges["bar -> baz"], (1, 2));
+        assert_eq!(d.edges["baz -> foo"], (2, 0));
+    }
 }

--- a/tests/extensions.rs
+++ b/tests/extensions.rs
@@ -79,3 +79,48 @@ fn implicit_some() {
 
     println!("implicit_some: {:#?}", d);
 }
+
+const CONFIG_E_R: &str = r##"
+#![enable(enum_repr)]
+
+#[repr(u8)]
+enum Vertices {
+    Foo,
+    Bar,
+    Baz
+}
+
+GraphData(
+    nodes: {
+        Foo: "foo",
+        Bar: "bar",
+        Baz: "baz",
+    },
+
+    edges: {
+        "foo -> bar": (Foo, Bar),
+        "bar -> baz": (Bar, Baz),
+        "baz -> foo": (Baz, Foo),
+
+    }
+)
+"##;
+
+#[derive(Debug, Deserialize)]
+struct GraphData {
+    nodes: HashMap<u8, String>,
+    edges: HashMap<String, (u8, u8)>,
+}
+
+#[test]
+fn enum_repr_deserialize() {
+    let d: GraphData = ron::de::from_str(&CONFIG_E_R).expect("Failed to deserialize");
+    println!("enum_repr {:#?}", d);
+}
+
+#[test]
+fn enum_repr_deserialize_correctly() {
+    let d: GraphData = ron::de::from_str(&CONFIG_E_R).expect("Failed to deserialize");
+    assert_eq!(d.nodes[&0], "foo");
+    assert_eq!(d.edges["foo -> bar"], (0, 1));
+}


### PR DESCRIPTION
Here is a first attempt at an implementation of the feature requested in #268
I've tried to reduce the impact on typical integer deserialization by introducing a feature gate for it.

Edit:
I forgot to note that the last commit which adds some stricter checking ends up requiring adding 'static lifetime to T: Num + 'static, in a few places, I can't confess to being familiar with lifetimes on non-reference values, but I couldn't figure out any way to add this check without it.