### PR TITLE
Add EBNF for multiline-comment to grammar docs

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -18,7 +18,7 @@ RON = [extensions], ws, value, ws;
 ```ebnf
 ws = { ws_single, comment };
 ws_single = "\n" | "\t" | "\r" | " ";
-comment = ["//", { no_newline }, "\n"];
+comment = ["//", { no_newline }, "\n"] | ["/*", { ? any character ? }, "*/"];
 ```
 
 ## Commas


### PR DESCRIPTION
Fixes a part of ( #98 )