### PR TITLE
Remove link to paid IntelliJ plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,7 @@ Why not XXX?
 
 ## Tooling
 
-IntelliJ:
-  - https://github.com/ron-rs/intellij-ron (free)
-  - https://vultix.github.io/intellij-ron-plugin/ (paid)
+IntelliJ: https://github.com/ron-rs/intellij-ron
 
 VS Code: https://github.com/a5huynh/vscode-ron
 


### PR DESCRIPTION
reviews say "broken and dev doesn't respond"

see https://plugins.jetbrains.com/plugin/12635-ron-rusty-object-notation-/reviews