### PR TITLE
Add EMACS tooling to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Atom: https://atom.io/packages/language-ron
 
 Vim: https://github.com/ron-rs/ron.vim
 
+EMACS: https://chiselapp.com/user/Hutzdog/repository/ron-mode/home
+
 ## License
 
 RON is dual-licensed under Apache-2.0 and MIT.


### PR DESCRIPTION
# Add EMACS tooling to the list of editor supports
### Synopsis
---
Over the past few months, I have been working on some EMACS tooling for RON. It is currently in MELPA and the Rust tooling for Spacemacs and EMACS Prelude, with Doom EMACS on the way. I feel it is now ready to be listed in the editor tooling list.

### Info
---
Source Code: https://chiselapp.com/user/Hutzdog/repository/ron-mode/home
MELPA package name: `ron-mode`
