### PR TITLE
[0.6] Support raw identifiers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,18 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
+      - uses: actions-rs/cargo@v1
+        name: Downgrade bitflags to MSRV
+        if: ${{ matrix.rust }} == "1.36.0"
+        with:
+          command: update
+          args: -p bitflags --precise 1.2.1
+      - uses: actions-rs/cargo@v1
+        name: Downgrade indexmap to MSRV
+        if: ${{ matrix.rust }} == "1.36.0"
+        with:
+          command: update
+          args: -p indexmap --precise 1.6.2
       - run: cargo test
       - run: cargo test --all-features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2021-09-09
+- support serde renames that start with a digit
+
 ## [0.6.3] - 2020-12-18
 - bump `base64` dependency to 0.13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ron"
 # Memo: update version in src/lib.rs too (doc link)
-version = "0.6.4"
+version = "0.6.5"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -203,6 +203,22 @@ fn untagged() {
 }
 
 #[test]
+fn rename() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    enum Foo {
+        #[serde(rename = "2d")]
+        D2,
+        #[serde(rename = "triangle-list")]
+        TriangleList,
+    }
+    assert_eq!(from_str::<Foo>("r#2d").unwrap(), Foo::D2);
+    assert_eq!(
+        from_str::<Foo>("r#triangle-list").unwrap(),
+        Foo::TriangleList
+    );
+}
+
+#[test]
 fn forgot_apostrophes() {
     let de: Result<(i32, String)> = from_str("(4, \"Hello)");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ Serializing / Deserializing is as simple as calling `to_string` / `from_str`.
 
 !*/
 
-#![doc(html_root_url = "https://docs.rs/ron/0.6.3")]
+#![doc(html_root_url = "https://docs.rs/ron/0.6.5")]
 
 pub mod de;
 pub mod ser;

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,0 +1,135 @@
+use super::to_string;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct EmptyStruct1;
+
+#[derive(Serialize)]
+struct EmptyStruct2 {}
+
+#[derive(Serialize)]
+struct MyStruct {
+    x: f32,
+    y: f32,
+}
+
+#[derive(Serialize)]
+enum MyEnum {
+    A,
+    B(bool),
+    C(bool, f32),
+    D { a: i32, b: i32 },
+}
+
+#[test]
+fn test_empty_struct() {
+    assert_eq!(to_string(&EmptyStruct1).unwrap(), "()");
+    assert_eq!(to_string(&EmptyStruct2 {}).unwrap(), "()");
+}
+
+#[test]
+fn test_struct() {
+    let my_struct = MyStruct { x: 4.0, y: 7.0 };
+
+    assert_eq!(to_string(&my_struct).unwrap(), "(x:4,y:7)");
+
+    #[derive(Serialize)]
+    struct NewType(i32);
+
+    assert_eq!(to_string(&NewType(42)).unwrap(), "(42)");
+
+    #[derive(Serialize)]
+    struct TupleStruct(f32, f32);
+
+    assert_eq!(to_string(&TupleStruct(2.0, 5.0)).unwrap(), "(2,5)");
+}
+
+#[test]
+fn test_option() {
+    assert_eq!(to_string(&Some(1u8)).unwrap(), "Some(1)");
+    assert_eq!(to_string(&None::<u8>).unwrap(), "None");
+}
+
+#[test]
+fn test_enum() {
+    assert_eq!(to_string(&MyEnum::A).unwrap(), "A");
+    assert_eq!(to_string(&MyEnum::B(true)).unwrap(), "B(true)");
+    assert_eq!(to_string(&MyEnum::C(true, 3.5)).unwrap(), "C(true,3.5)");
+    assert_eq!(to_string(&MyEnum::D { a: 2, b: 3 }).unwrap(), "D(a:2,b:3)");
+}
+
+#[test]
+fn test_array() {
+    let empty: [i32; 0] = [];
+    assert_eq!(to_string(&empty).unwrap(), "()");
+    let empty_ref: &[i32] = &empty;
+    assert_eq!(to_string(&empty_ref).unwrap(), "[]");
+
+    assert_eq!(to_string(&[2, 3, 4i32]).unwrap(), "(2,3,4)");
+    assert_eq!(to_string(&(&[2, 3, 4i32] as &[i32])).unwrap(), "[2,3,4]");
+}
+
+#[test]
+fn test_map() {
+    use std::collections::HashMap;
+
+    let mut map = HashMap::new();
+    map.insert((true, false), 4);
+    map.insert((false, false), 123);
+
+    let s = to_string(&map).unwrap();
+    s.starts_with("{");
+    s.contains("(true,false):4");
+    s.contains("(false,false):123");
+    s.ends_with("}");
+}
+
+#[test]
+fn test_string() {
+    assert_eq!(to_string(&"Some string").unwrap(), "\"Some string\"");
+}
+
+#[test]
+fn test_char() {
+    assert_eq!(to_string(&'c').unwrap(), "'c'");
+}
+
+#[test]
+fn test_escape() {
+    assert_eq!(to_string(&r#""Quoted""#).unwrap(), r#""\"Quoted\"""#);
+}
+
+#[test]
+fn test_byte_stream() {
+    use serde_bytes;
+
+    let small: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    assert_eq!(
+        to_string(&small).unwrap(),
+        "(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)"
+    );
+
+    let large = vec![255u8; 64];
+    let large = serde_bytes::Bytes::new(&large);
+    assert_eq!(
+        to_string(&large).unwrap(),
+        concat!(
+            "\"/////////////////////////////////////////",
+            "////////////////////////////////////////////w==\""
+        )
+    );
+}
+
+#[test]
+fn rename() {
+    #[derive(Serialize, Debug, PartialEq)]
+    enum Foo {
+        #[serde(rename = "2d")]
+        D2,
+        #[serde(rename = "triangle-list")]
+        TriangleList,
+    }
+
+    assert_eq!(to_string(&Foo::D2).unwrap(), "r#2d");
+    assert_eq!(to_string(&Foo::TriangleList).unwrap(), "r#triangle-list");
+}


### PR DESCRIPTION
Required for https://github.com/gfx-rs/wgpu/issues/1931
```rust
enum Foo {
  #[serde(rename = "2d")]
  D2,
}
```


@torkleyy are you around to look at this?