### PR TITLE
Remove Gitter badge in favour of Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/ron.svg)](https://crates.io/crates/ron)
 [![MSRV](https://img.shields.io/badge/MSRV-1.36.0-orange)](https://github.com/ron-rs/ron)
 [![Docs](https://docs.rs/ron/badge.svg)](https://docs.rs/ron)
-[![Gitter](https://badges.gitter.im/ron-rs/ron.svg)](https://gitter.im/ron-rs/ron)
+[![Matrix](https://img.shields.io/matrix/ron-rs:matrix.org.svg)](https://matrix.to/#/#ron-rs:matrix.org)
 
 RON is a simple readable data serialization format that looks similar to Rust syntax.
 It's designed to support all of [Serde's data model](https://serde.rs/data-model.html), so


### PR DESCRIPTION
cc @kvark 

GitHub still has the old badge cached so some "room not world readable or is invalid" badges might show up for a while.

[![Matrix](https://img.shields.io/matrix/ron-rs:matrix.org)](https://matrix.to/#/#ron-rs:matrix.org)