### PR TITLE
Fix newtype variant unwrapping inside enum, seq and map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Add `struct_names` option to `PrettyConfig`
+- Fix newtype variant unwrapping around enum, seq and map ([#331](https://github.com/ron-rs/ron/pull/331))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -129,6 +129,10 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        // Newtype variants can only be unwrapped if we receive information
+        //  about the wrapped type - with `deserialize_any` we don't
+        self.newtype_variant = false;
+
         if self.bytes.consume_ident("true") {
             return visitor.visit_bool(true);
         } else if self.bytes.consume_ident("false") {
@@ -414,6 +418,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        self.newtype_variant = false;
+
         if self.bytes.consume("[") {
             let value = visitor.visit_seq(CommaSeparated::new(b']', &mut self))?;
             self.bytes.comma()?;
@@ -469,6 +475,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        self.newtype_variant = false;
+
         if self.bytes.consume("{") {
             let value = visitor.visit_map(CommaSeparated::new(b'}', &mut self))?;
             self.bytes.comma()?;
@@ -524,6 +532,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        self.newtype_variant = false;
+
         visitor.visit_enum(Enum::new(self))
     }
 


### PR DESCRIPTION
This is a follow-up to #319 which added the `unwrap_variant_newtypes` extension.

Unfortunately, it seems like I missed a few interactions with parsing enums, sequences and maps nested inside a newtype variant (i.e. not inside a containing non-newtype struct). I have fixed all three and added extra test cases to cover their intended functionality, i.e. `NewtypeVariant( [ Struct(...) ] )`, `NewtypeVariant( { "key": Struct(...) } )`, and `NewtypeVariant( StructVariant(...) )` all parse again.

### Discussion

`Option<T>` is another fun case. Here I think carrying through the unwrapping actually is quite neat, but I want to get your input if this should be the intended behaviour:
* `NewtypeVariant( None )`
* `NewtypeVariant( Some(a: 4, bool: false) )` for `Option<Struct>` and `struct Struct { a: u32, b: bool }`
* `NewtypeVariant( a: 4, bool: false )` is the `implicit_some` extension is switched on as well

I am also a bit unsure about how to handle `deserialize_any`. I think I may need your help with that one.

### TODO
* [x] I've included my change in `CHANGELOG.md`


