### PR TITLE
Enable `unwrap_newtypes` extension during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - Add `struct_names` option to `PrettyConfig`
 - Fix newtype variant unwrapping around enum, seq and map ([#331](https://github.com/ron-rs/ron/pull/331))
+- Implement `unwrap_newtypes` extension during serialization ([#333](https://github.com/ron-rs/ron/pull/333))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -97,7 +97,8 @@ pub struct PrettyConfig {
     /// Always include the decimal in floats
     #[serde(default = "default_decimal_floats")]
     pub decimal_floats: bool,
-    /// Enable extensions. Only configures 'implicit_some' for now.
+    /// Enable extensions. Only configures 'implicit_some'
+    ///  and 'unwrap_newtypes' for now.
     pub extensions: Extensions,
     /// Private field to ensure adding a field is non-breaking.
     #[serde(skip)]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -261,6 +261,10 @@ impl<W: io::Write> Serializer<W> {
                 writer.write_all(b"#![enable(implicit_some)]")?;
                 writer.write_all(conf.new_line.as_bytes())?;
             };
+            if conf.extensions.contains(Extensions::UNWRAP_NEWTYPES) {
+                writer.write_all(b"#![enable(unwrap_newtypes)]")?;
+                writer.write_all(conf.new_line.as_bytes())?;
+            };
         };
         Ok(Serializer {
             output: writer,
@@ -521,6 +525,10 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     where
         T: ?Sized + Serialize,
     {
+        if self.extensions().contains(Extensions::UNWRAP_NEWTYPES) {
+            return value.serialize(&mut *self);
+        }
+
         if self.struct_names() {
             self.write_identifier(name)?;
         }

--- a/tests/extensions.rs
+++ b/tests/extensions.rs
@@ -50,6 +50,16 @@ fn unwrap_newtypes() {
     let d: Struct = ron::de::from_str(CONFIG_U_NT).expect("Failed to deserialize");
 
     println!("unwrap_newtypes: {:#?}", d);
+
+    let s = ron::ser::to_string_pretty(
+        &d,
+        ron::ser::PrettyConfig::default().extensions(ron::extensions::Extensions::UNWRAP_NEWTYPES),
+    )
+    .expect("Failed to serialize");
+
+    let d2: Struct = ron::de::from_str(&s).expect("Failed to deserialize");
+
+    assert_eq!(d, d2);
 }
 
 const CONFIG_I_S: &str = "


### PR DESCRIPTION
This PR fixes #284 and implements newtype unwrapping during serialization. E.g.

```rust
#[derive(Serialize)]
struct MyFloat(f64);
```

now serializes to `4.2` instead of `MyFloat(4.2)` or `(4.2)`. Enabling the extension also adds the extension enabling attribute to the top of the serialized RON.

* [x] I've included my change in `CHANGELOG.md`
