### PR TITLE
Enable `unwrap_variant_newtypes` extension during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `struct_names` option to `PrettyConfig`
 - Fix newtype variant unwrapping around enum, seq and map ([#331](https://github.com/ron-rs/ron/pull/331))
 - Implement `unwrap_newtypes` extension during serialization ([#333](https://github.com/ron-rs/ron/pull/333))
+- Implement `unwrap_variant_newtypes` extension during serialization ([#336](https://github.com/ron-rs/ron/pull/336))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -97,8 +97,8 @@ pub struct PrettyConfig {
     /// Always include the decimal in floats
     #[serde(default = "default_decimal_floats")]
     pub decimal_floats: bool,
-    /// Enable extensions. Only configures 'implicit_some'
-    ///  and 'unwrap_newtypes' for now.
+    /// Enable extensions. Only configures 'implicit_some',
+    ///  'unwrap_newtypes', and 'unwrap_variant_newtypes' for now.
     pub extensions: Extensions,
     /// Private field to ensure adding a field is non-breaking.
     #[serde(skip)]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -250,6 +250,7 @@ pub struct Serializer<W: io::Write> {
     output: W,
     pretty: Option<(PrettyConfig, Pretty)>,
     is_empty: Option<bool>,
+    newtype_variant: bool,
 }
 
 impl<W: io::Write> Serializer<W> {
@@ -266,6 +267,13 @@ impl<W: io::Write> Serializer<W> {
                 writer.write_all(b"#![enable(unwrap_newtypes)]")?;
                 writer.write_all(conf.new_line.as_bytes())?;
             };
+            if conf
+                .extensions
+                .contains(Extensions::UNWRAP_VARIANT_NEWTYPES)
+            {
+                writer.write_all(b"#![enable(unwrap_variant_newtypes)]")?;
+                writer.write_all(conf.new_line.as_bytes())?;
+            };
         };
         Ok(Serializer {
             output: writer,
@@ -279,6 +287,7 @@ impl<W: io::Write> Serializer<W> {
                 )
             }),
             is_empty: None,
+            newtype_variant: false,
         })
     }
 
@@ -501,13 +510,17 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     fn serialize_unit(self) -> Result<()> {
-        self.output.write_all(b"()")?;
+        if !self.newtype_variant {
+            self.output.write_all(b"()")?;
+        }
+
+        self.newtype_variant = false;
 
         Ok(())
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<()> {
-        if self.struct_names() {
+        if self.struct_names() && !self.newtype_variant {
             self.write_identifier(name)?;
 
             Ok(())
@@ -526,7 +539,9 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     where
         T: ?Sized + Serialize,
     {
-        if self.extensions().contains(Extensions::UNWRAP_NEWTYPES) {
+        if self.extensions().contains(Extensions::UNWRAP_NEWTYPES) || self.newtype_variant {
+            self.newtype_variant = false;
+
             return value.serialize(&mut *self);
         }
 
@@ -553,13 +568,21 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         self.write_identifier(variant)?;
         self.output.write_all(b"(")?;
 
+        self.newtype_variant = self
+            .extensions()
+            .contains(Extensions::UNWRAP_VARIANT_NEWTYPES);
+
         value.serialize(&mut *self)?;
+
+        self.newtype_variant = false;
 
         self.output.write_all(b")")?;
         Ok(())
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        self.newtype_variant = false;
+
         self.output.write_all(b"[")?;
 
         if let Some(len) = len {
@@ -575,11 +598,17 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         Ok(Compound {
             ser: self,
             state: State::First,
+            newtype_variant: false,
         })
     }
 
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
-        self.output.write_all(b"(")?;
+        let old_newtype_variant = self.newtype_variant;
+        self.newtype_variant = false;
+
+        if !old_newtype_variant {
+            self.output.write_all(b"(")?;
+        }
 
         if self.separate_tuple_members() {
             self.is_empty = Some(len == 0);
@@ -590,6 +619,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         Ok(Compound {
             ser: self,
             state: State::First,
+            newtype_variant: old_newtype_variant,
         })
     }
 
@@ -598,7 +628,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
-        if self.struct_names() {
+        if self.struct_names() && !self.newtype_variant {
             self.write_identifier(name)?;
         }
 
@@ -612,6 +642,8 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
+        self.newtype_variant = false;
+
         self.write_identifier(variant)?;
         self.output.write_all(b"(")?;
 
@@ -624,10 +656,13 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         Ok(Compound {
             ser: self,
             state: State::First,
+            newtype_variant: false,
         })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
+        self.newtype_variant = false;
+
         self.output.write_all(b"{")?;
 
         if let Some(len) = len {
@@ -639,14 +674,20 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         Ok(Compound {
             ser: self,
             state: State::First,
+            newtype_variant: false,
         })
     }
 
     fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
-        if self.struct_names() {
-            self.write_identifier(name)?;
+        let old_newtype_variant = self.newtype_variant;
+        self.newtype_variant = false;
+
+        if !old_newtype_variant {
+            if self.struct_names() {
+                self.write_identifier(name)?;
+            }
+            self.output.write_all(b"(")?;
         }
-        self.output.write_all(b"(")?;
 
         self.is_empty = Some(len == 0);
         self.start_indent()?;
@@ -654,6 +695,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         Ok(Compound {
             ser: self,
             state: State::First,
+            newtype_variant: old_newtype_variant,
         })
     }
 
@@ -664,6 +706,8 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
+        self.newtype_variant = false;
+
         self.write_identifier(variant)?;
         self.output.write_all(b"(")?;
 
@@ -673,6 +717,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
         Ok(Compound {
             ser: self,
             state: State::First,
+            newtype_variant: false,
         })
     }
 }
@@ -684,6 +729,7 @@ pub enum State {
 pub struct Compound<'a, W: io::Write> {
     ser: &'a mut Serializer<W>,
     state: State,
+    newtype_variant: bool,
 }
 
 impl<'a, W: io::Write> ser::SerializeSeq for Compound<'a, W> {
@@ -734,6 +780,7 @@ impl<'a, W: io::Write> ser::SerializeSeq for Compound<'a, W> {
             pretty.sequence_index.pop();
         }
 
+        // seq always disables `self.newtype_variant`
         self.ser.output.write_all(b"]")?;
         Ok(())
     }
@@ -786,7 +833,9 @@ impl<'a, W: io::Write> ser::SerializeTuple for Compound<'a, W> {
             self.ser.end_indent()?;
         }
 
-        self.ser.output.write_all(b")")?;
+        if !self.newtype_variant {
+            self.ser.output.write_all(b")")?;
+        }
 
         Ok(())
     }
@@ -873,6 +922,7 @@ impl<'a, W: io::Write> ser::SerializeMap for Compound<'a, W> {
             }
         }
         self.ser.end_indent()?;
+        // map always disables `self.newtype_variant`
         self.ser.output.write_all(b"}")?;
         Ok(())
     }
@@ -920,7 +970,9 @@ impl<'a, W: io::Write> ser::SerializeStruct for Compound<'a, W> {
             }
         }
         self.ser.end_indent()?;
-        self.ser.output.write_all(b")")?;
+        if !self.newtype_variant {
+            self.ser.output.write_all(b")")?;
+        }
         Ok(())
     }
 }

--- a/tests/250_variant_newtypes.rs
+++ b/tests/250_variant_newtypes.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
-use ron::{de::from_str, error::ErrorCode};
-use serde::Deserialize;
+use ron::{
+    de::from_str, error::ErrorCode, extensions::Extensions, ser::to_string_pretty,
+    ser::PrettyConfig,
+};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 enum TestEnum {
     Unit,
     PrimitiveNewtype(String),
@@ -20,22 +23,22 @@ enum TestEnum {
     TupleNewtypeMap(HashMap<u32, Struct>),
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 struct Unit;
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 struct Newtype(i32);
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 struct TupleStruct(u32, bool);
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 struct Struct {
     a: u32,
     b: bool,
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 enum Enum {
     A,
     B(Struct),
@@ -278,5 +281,128 @@ fn test_deserialise_tuple_newtypes() {
         )
         .unwrap(),
         TestEnum::TupleNewtypeMap(vec![(8, Struct { a: 4, b: false })].into_iter().collect()),
+    );
+}
+
+#[test]
+fn test_serialise_non_newtypes() {
+    assert_eq_serialize_roundtrip(TestEnum::Unit, Extensions::UNWRAP_VARIANT_NEWTYPES);
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::PrimitiveNewtype(String::from("hi")),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::Tuple(4, false),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::Struct { a: 4, b: false },
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+}
+
+#[test]
+fn test_serialise_tuple_newtypes() {
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeUnit(Unit),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeNewtype(Newtype(4)),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeNewtype(Newtype(4)),
+        Extensions::UNWRAP_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeNewtype(Newtype(4)),
+        Extensions::UNWRAP_VARIANT_NEWTYPES | Extensions::UNWRAP_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeTuple((4, false)),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeTupleStruct(TupleStruct(4, false)),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeStruct(Struct { a: 4, b: false }),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeEnum(Enum::A),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeEnum(Enum::B(Struct { a: 4, b: false })),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeEnum(Enum::C(4, false)),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeEnum(Enum::D { a: 4, b: false }),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeOption(None),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeOption(Some(Struct { a: 4, b: false })),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeOption(Some(Struct { a: 4, b: false })),
+        Extensions::IMPLICIT_SOME,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeOption(Some(Struct { a: 4, b: false })),
+        Extensions::UNWRAP_VARIANT_NEWTYPES | Extensions::IMPLICIT_SOME,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeSeq(vec![]),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeSeq(vec![Struct { a: 4, b: false }]),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeMap(vec![].into_iter().collect()),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+    assert_eq_serialize_roundtrip(
+        TestEnum::TupleNewtypeMap(vec![(2, Struct { a: 4, b: false })].into_iter().collect()),
+        Extensions::UNWRAP_VARIANT_NEWTYPES,
+    );
+}
+
+fn assert_eq_serialize_roundtrip<
+    S: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+>(
+    value: S,
+    extensions: Extensions,
+) {
+    assert_eq!(
+        from_str::<S>(
+            &to_string_pretty(&value, PrettyConfig::default().extensions(extensions)).unwrap()
+        )
+        .unwrap(),
+        value,
     );
 }


### PR DESCRIPTION
This PR is a follow-up to #333 and implements newtype variant unwrapping during serialization (i.e. the inverse of #319). E.g.

```rust
#[derive(Serialize)]
struct Inner { x: u32 }

#[derive(Serialize)]
enum MyEnum {
    Newtype(Inner),
    ...
}
```

now serializes to `Newtype(x: 42)` instead of `Newtype(Inner(x: 4.2))` or `Newtype((x: 4.2))`. Enabling the extension also adds the extension enabling attribute to the top of the serialized RON.

* [x] I've included my change in `CHANGELOG.md`
