### PR TITLE
Add `output_extensions` option to `PrettyConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix newtype variant unwrapping around enum, seq and map ([#331](https://github.com/ron-rs/ron/pull/331))
 - Implement `unwrap_newtypes` extension during serialization ([#333](https://github.com/ron-rs/ron/pull/333))
 - Implement `unwrap_variant_newtypes` extension during serialization ([#336](https://github.com/ron-rs/ron/pull/336))
+- Add `output_extensions` option to `Pretty Config` ([#339](https://github.com/ron-rs/ron/pull/339))
 
 ## [0.7.0] - 2021-10-22
 


### PR DESCRIPTION
This PR adds an extra on-by-default configuration option to `PrettyConfig`. When `output_extensions` is set to `false`, the serialized RON will **not** include the `#![enable(EXTENSION)]` attributes.

This would also be related to #281, i.e. for use cases where RON is used e.g. for a configuration file that is both produced and consumed by the same program, extensions could be automatically enabled on deserialization and removed on serialization to remove the overhead.

While programmatically enabling extensions is doable already (just insert the attribute-enabling string before the RON), disabling them is much harder as you would have to parse and match on the attributes' format.

* [x] I've included my change in `CHANGELOG.md`
