### PR TITLE
chore(deps): use exact version for bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,9 @@ repository = "https://github.com/ron-rs/ron"
 documentation = "https://docs.rs/ron/"
 exclude = ["bors.toml", ".travis.yml"]
 
-[lib]
-name = "ron"
-
 [dependencies]
 base64 = "0.13"
-bitflags = "1.0.4"
+bitflags = "=1.2.1"
 indexmap = { version = "1.0.2", features = ["serde-1"], optional = true }
 serde = { version = "1.0.60", features = ["serde_derive"] }
 


### PR DESCRIPTION
Motivation: allow building with MSRV without patching lock file - see #332

Usually this is discouraged, but `bitflags` only provides a macro that generates code for us, so if it gets included with multiple different versions in a dependency tree it won't cause any issues.

* ~~[x] I've included my change in `CHANGELOG.md`~~ not necesary
