### PR TITLE
Expose `Extensions` during ser+de through `ron::Options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue [#338](https://github.com/ron-rs/ron/issues/338) value map roundtrip ([#341](https://github.com/ron-rs/ron/pull/341))
 - Fix issue [#289](https://github.com/ron-rs/ron/issues/289) enumerate_arrays comments ([#344](https://github.com/ron-rs/ron/pull/344))
 - Report struct name in expected struct error ([#342](https://github.com/ron-rs/ron/pull/342))
+- Add `Options` builder to configure the RON serde roundtrip ([#343](https://github.com/ron-rs/ron/pull/343))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,5 @@
 /// Deserialization module.
-pub use crate::error::{Error, ErrorCode, Result};
-pub use crate::parse::Position;
+pub use crate::error::{Error, ErrorCode, Position, Result};
 
 use serde::de::{self, DeserializeSeed, Deserializer as SerdeError, Visitor};
 use std::{borrow::Cow, io, str};
@@ -31,20 +30,26 @@ impl<'de> Deserializer<'de> {
     // Cannot implement trait here since output is tied to input lifetime 'de.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &'de str) -> Result<Self> {
-        Deserializer::from_bytes(input.as_bytes())
+        Self::from_str_with_options(input, Options::default())
     }
 
     pub fn from_bytes(input: &'de [u8]) -> Result<Self> {
-        Ok(Deserializer {
-            bytes: Bytes::new(input)?,
-            newtype_variant: false,
-        })
+        Self::from_bytes_with_options(input, Options::default())
     }
 
-    #[must_use]
-    pub fn with_default_extensions(mut self, default_extensions: Extensions) -> Self {
-        self.bytes.exts |= default_extensions;
-        self
+    pub fn from_str_with_options(input: &'de str, options: Options) -> Result<Self> {
+        Self::from_bytes_with_options(input.as_bytes(), options)
+    }
+
+    pub fn from_bytes_with_options(input: &'de [u8], options: Options) -> Result<Self> {
+        let mut deserializer = Deserializer {
+            bytes: Bytes::new(input)?,
+            newtype_variant: false,
+        };
+
+        deserializer.bytes.exts |= options.default_extensions;
+
+        Ok(deserializer)
     }
 
     pub fn remainder(&self) -> Cow<'_, str> {
@@ -59,7 +64,7 @@ where
     R: io::Read,
     T: de::DeserializeOwned,
 {
-    Options::build().from_reader(rdr)
+    Options::default().from_reader(rdr)
 }
 
 /// A convenience function for building a deserializer
@@ -68,7 +73,7 @@ pub fn from_str<'a, T>(s: &'a str) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    Options::build().from_str(s)
+    Options::default().from_str(s)
 }
 
 /// A convenience function for building a deserializer
@@ -77,7 +82,7 @@ pub fn from_bytes<'a, T>(s: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    Options::build().from_bytes(s)
+    Options::default().from_bytes(s)
 }
 
 impl<'de> Deserializer<'de> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,6 @@
 use serde::{de, ser};
 use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Error};
 
-pub use crate::parse::Position;
-
 /// This type represents all possible errors that can occur when
 /// serializing or deserializing RON data.
 #[derive(Clone, Debug, PartialEq)]
@@ -112,6 +110,18 @@ impl fmt::Display for ErrorCode {
             ErrorCode::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
             _ => f.write_str("Unknown ErrorCode"),
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Position {
+    pub line: usize,
+    pub col: usize,
+}
+
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.line, self.col)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,11 @@ pub mod value;
 
 pub mod extensions;
 
+pub mod options;
+
 pub use de::{from_str, Deserializer};
 pub use error::{Error, Result};
+pub use options::Options;
 pub use ser::{to_string, Serializer};
 pub use value::{Map, Number, Value};
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -35,12 +35,16 @@ pub struct Options {
     ///  activation is NOT included in the output RON.
     /// No extensions are enabled by default.
     pub default_extensions: Extensions,
+    /// Private field to ensure adding a field is non-breaking.
+    #[serde(skip)]
+    _future_proof: (),
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
             default_extensions: Extensions::empty(),
+            _future_proof: (),
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,123 @@
+use std::io;
+
+use serde::{de, ser};
+
+use crate::de::Deserializer;
+use crate::error::Result;
+use crate::extensions::Extensions;
+use crate::ser::{PrettyConfig, Serializer};
+
+pub struct Options {
+    default_extensions: Extensions,
+}
+
+impl Options {
+    #[must_use]
+    pub fn build() -> Self {
+        Self {
+            default_extensions: Extensions::empty(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_default_extension(mut self, default_extension: Extensions) -> Self {
+        self.default_extensions |= default_extension;
+        self
+    }
+
+    #[must_use]
+    pub fn without_default_extension(mut self, default_extension: Extensions) -> Self {
+        self.default_extensions &= !default_extension;
+        self
+    }
+}
+
+impl Options {
+    /// A convenience function for reading data from a reader
+    /// and feeding into a deserializer.
+    pub fn from_reader<R, T>(&self, mut rdr: R) -> Result<T>
+    where
+        R: io::Read,
+        T: de::DeserializeOwned,
+    {
+        let mut bytes = Vec::new();
+        rdr.read_to_end(&mut bytes)?;
+
+        self.from_bytes(&bytes)
+    }
+
+    /// A convenience function for building a deserializer
+    /// and deserializing a value of type `T` from a string.
+    pub fn from_str<'a, T>(&self, s: &'a str) -> Result<T>
+    where
+        T: de::Deserialize<'a>,
+    {
+        self.from_bytes(s.as_bytes())
+    }
+
+    /// A convenience function for building a deserializer
+    /// and deserializing a value of type `T` from bytes.
+    pub fn from_bytes<'a, T>(&self, s: &'a [u8]) -> Result<T>
+    where
+        T: de::Deserialize<'a>,
+    {
+        let mut deserializer =
+            Deserializer::from_bytes(s)?.with_default_extensions(self.default_extensions);
+        let t = T::deserialize(&mut deserializer)?;
+
+        deserializer.end()?;
+
+        Ok(t)
+    }
+
+    /// Serializes `value` into `writer`
+    pub fn to_writer<W, T>(&self, writer: W, value: &T) -> Result<()>
+    where
+        W: io::Write,
+        T: ?Sized + ser::Serialize,
+    {
+        let mut s = Serializer::new_with_default_extensions(writer, None, self.default_extensions)?;
+        value.serialize(&mut s)
+    }
+
+    /// Serializes `value` into `writer` in a pretty way.
+    pub fn to_writer_pretty<W, T>(&self, writer: W, value: &T, config: PrettyConfig) -> Result<()>
+    where
+        W: io::Write,
+        T: ?Sized + ser::Serialize,
+    {
+        let mut s =
+            Serializer::new_with_default_extensions(writer, Some(config), self.default_extensions)?;
+        value.serialize(&mut s)
+    }
+
+    /// Serializes `value` and returns it as string.
+    ///
+    /// This function does not generate any newlines or nice formatting;
+    /// if you want that, you can use `to_string_pretty` instead.
+    pub fn to_string<T>(&self, value: &T) -> Result<String>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let mut output = Vec::new();
+        let mut s =
+            Serializer::new_with_default_extensions(&mut output, None, self.default_extensions)?;
+        value.serialize(&mut s)?;
+        Ok(String::from_utf8(output).expect("Ron should be utf-8"))
+    }
+
+    /// Serializes `value` in the recommended RON layout in a pretty way.
+    pub fn to_string_pretty<T>(&self, value: &T, config: PrettyConfig) -> Result<String>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let mut output = Vec::new();
+        let mut s = Serializer::new_with_default_extensions(
+            &mut output,
+            Some(config),
+            self.default_extensions,
+        )?;
+        value.serialize(&mut s)?;
+        Ok(String::from_utf8(output).expect("Ron should be utf-8"))
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,12 +2,11 @@
 
 use std::{
     char::from_u32 as char_from_u32,
-    fmt::{Display, Formatter, Result as FmtResult},
     str::{from_utf8, from_utf8_unchecked, FromStr},
 };
 
 use crate::{
-    error::{Error, ErrorCode, Result},
+    error::{Error, ErrorCode, Position, Result},
     extensions::Extensions,
 };
 
@@ -920,18 +919,6 @@ impl_num!(u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 pub enum ParsedStr<'a> {
     Allocated(String),
     Slice(&'a str),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Position {
-    pub line: usize,
-    pub col: usize,
-}
-
-impl Display for Position {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}:{}", self.line, self.col)
-    }
 }
 
 #[cfg(test)]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -18,7 +18,7 @@ where
     W: io::Write,
     T: ?Sized + Serialize,
 {
-    Options::build().to_writer(writer, value)
+    Options::default().to_writer(writer, value)
 }
 
 /// Serializes `value` into `writer` in a pretty way.
@@ -27,7 +27,7 @@ where
     W: io::Write,
     T: ?Sized + Serialize,
 {
-    Options::build().to_writer_pretty(writer, value, config)
+    Options::default().to_writer_pretty(writer, value, config)
 }
 
 /// Serializes `value` and returns it as string.
@@ -38,7 +38,7 @@ pub fn to_string<T>(value: &T) -> Result<String>
 where
     T: ?Sized + Serialize,
 {
-    Options::build().to_string(value)
+    Options::default().to_string(value)
 }
 
 /// Serializes `value` in the recommended RON layout in a pretty way.
@@ -46,7 +46,7 @@ pub fn to_string_pretty<T>(value: &T, config: PrettyConfig) -> Result<String>
 where
     T: ?Sized + Serialize,
 {
-    Options::build().to_string_pretty(value, config)
+    Options::default().to_string_pretty(value, config)
 }
 
 /// Pretty serializer state
@@ -70,25 +70,18 @@ struct Pretty {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PrettyConfig {
     /// Limit the pretty-ness up to the given depth.
-    #[serde(default = "default_depth_limit")]
     pub depth_limit: usize,
     /// New line string
-    #[serde(default = "default_new_line")]
     pub new_line: String,
     /// Indentation string
-    #[serde(default = "default_indentor")]
     pub indentor: String,
     // Whether to emit struct names
-    #[serde(default = "default_struct_names")]
     pub struct_names: bool,
     /// Separate tuple members with indentation
-    #[serde(default = "default_separate_tuple_members")]
     pub separate_tuple_members: bool,
     /// Enumerate array items in comments
-    #[serde(default = "default_enumerate_arrays")]
     pub enumerate_arrays: bool,
     /// Always include the decimal in floats
-    #[serde(default = "default_decimal_floats")]
     pub decimal_floats: bool,
     /// Enable extensions. Only configures 'implicit_some',
     ///  'unwrap_newtypes', and 'unwrap_variant_newtypes' for now.
@@ -186,50 +179,21 @@ impl PrettyConfig {
     }
 }
 
-fn default_depth_limit() -> usize {
-    !0
-}
-
-fn default_new_line() -> String {
-    #[cfg(not(target_os = "windows"))]
-    let new_line = "\n".to_string();
-    #[cfg(target_os = "windows")]
-    let new_line = "\r\n".to_string();
-
-    new_line
-}
-
-fn default_decimal_floats() -> bool {
-    false
-}
-
-fn default_indentor() -> String {
-    "    ".to_string()
-}
-
-fn default_struct_names() -> bool {
-    false
-}
-
-fn default_separate_tuple_members() -> bool {
-    false
-}
-
-fn default_enumerate_arrays() -> bool {
-    false
-}
-
 impl Default for PrettyConfig {
     fn default() -> Self {
         PrettyConfig {
-            depth_limit: default_depth_limit(),
-            new_line: default_new_line(),
-            indentor: default_indentor(),
-            struct_names: default_struct_names(),
-            separate_tuple_members: default_separate_tuple_members(),
-            enumerate_arrays: default_enumerate_arrays(),
-            extensions: Extensions::default(),
-            decimal_floats: default_decimal_floats(),
+            depth_limit: !0,
+            new_line: if cfg!(not(target_os = "windows")) {
+                String::from("\n")
+            } else {
+                String::from("\r\n")
+            },
+            indentor: String::from("    "),
+            struct_names: false,
+            separate_tuple_members: false,
+            enumerate_arrays: false,
+            extensions: Extensions::empty(),
+            decimal_floats: false,
             _future_proof: (),
         }
     }
@@ -252,19 +216,19 @@ impl<W: io::Write> Serializer<W> {
     ///
     /// Most of the time you can just use `to_string` or `to_string_pretty`.
     pub fn new(writer: W, config: Option<PrettyConfig>) -> Result<Self> {
-        Self::new_with_default_extensions(writer, config, Extensions::empty())
+        Self::with_options(writer, config, Options::default())
     }
 
     /// Creates a new `Serializer`.
     ///
     /// Most of the time you can just use `to_string` or `to_string_pretty`.
-    pub fn new_with_default_extensions(
+    pub fn with_options(
         mut writer: W,
         config: Option<PrettyConfig>,
-        default_extensions: Extensions,
+        options: Options,
     ) -> Result<Self> {
         if let Some(conf) = &config {
-            let non_default_extensions = !default_extensions;
+            let non_default_extensions = !options.default_extensions;
 
             if (non_default_extensions & conf.extensions).contains(Extensions::IMPLICIT_SOME) {
                 writer.write_all(b"#![enable(implicit_some)]")?;
@@ -292,7 +256,7 @@ impl<W: io::Write> Serializer<W> {
                     },
                 )
             }),
-            default_extensions,
+            default_extensions: options.default_extensions,
             is_empty: None,
             newtype_variant: false,
         })
@@ -731,10 +695,12 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     }
 }
 
-pub enum State {
+enum State {
     First,
     Rest,
 }
+
+#[doc(hidden)]
 pub struct Compound<'a, W: io::Write> {
     ser: &'a mut Serializer<W>,
     state: State,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -68,6 +68,7 @@ struct Pretty {
 ///     .indentor("\t".to_owned());
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct PrettyConfig {
     /// Limit the pretty-ness up to the given depth.
     pub depth_limit: usize,

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+use ron::{extensions::Extensions, ser::PrettyConfig, Options};
+
+#[derive(Serialize, Deserialize)]
+struct Newtype(f64);
+
+#[derive(Serialize, Deserialize)]
+struct Struct(Option<u32>, Newtype);
+
+#[test]
+fn default_options() {
+    let ron = Options::build();
+
+    let de: Struct = ron.from_str("(Some(42),(4.2))").unwrap();
+    let ser = ron.to_string(&de).unwrap();
+
+    assert_eq!(ser, "(Some(42),(4.2))")
+}
+
+#[test]
+fn single_default_extension() {
+    let ron = Options::build().with_default_extension(Extensions::IMPLICIT_SOME);
+
+    let de: Struct = ron.from_str("(42,(4.2))").unwrap();
+    let ser = ron.to_string(&de).unwrap();
+
+    assert_eq!(ser, "(42,(4.2))");
+
+    let de: Struct = ron.from_str("#![enable(implicit_some)](42,(4.2))").unwrap();
+    let ser = ron.to_string(&de).unwrap();
+
+    assert_eq!(ser, "(42,(4.2))");
+
+    let de: Struct = ron
+        .from_str("#![enable(implicit_some)]#![enable(unwrap_newtypes)](42,4.2)")
+        .unwrap();
+    let ser = ron.to_string(&de).unwrap();
+
+    assert_eq!(ser, "(42,(4.2))");
+
+    let de: Struct = ron
+        .from_str("#![enable(implicit_some)]#![enable(unwrap_newtypes)](42,4.2)")
+        .unwrap();
+    let ser = ron
+        .to_string_pretty(
+            &de,
+            PrettyConfig::default().extensions(Extensions::UNWRAP_NEWTYPES),
+        )
+        .unwrap();
+
+    assert_eq!(ser, "#![enable(unwrap_newtypes)]\n(42, 4.2)");
+}

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -10,7 +10,7 @@ struct Struct(Option<u32>, Newtype);
 
 #[test]
 fn default_options() {
-    let ron = Options::build();
+    let ron = Options::default();
 
     let de: Struct = ron.from_str("(Some(42),(4.2))").unwrap();
     let ser = ron.to_string(&de).unwrap();
@@ -20,7 +20,7 @@ fn default_options() {
 
 #[test]
 fn single_default_extension() {
-    let ron = Options::build().with_default_extension(Extensions::IMPLICIT_SOME);
+    let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
 
     let de: Struct = ron.from_str("(42,(4.2))").unwrap();
     let ser = ron.to_string(&de).unwrap();


### PR DESCRIPTION
This PR is based on #281 and #339 (with a potential application for #334 as well).

1) It adds a new `Options` struct from which all ser+de utils methods can be called.
2) The existing utils methods `XXX` now use `Options::default().XXX` as their implementation.
3) The `Options` struct can be configured with a set of default RON extensions
  a) During deserialization default extensions are automatically enabled, i.e. do not have to be included in the RON.
  b) During serialization default extensions are automatically enabled and are **not** included in the output RON. Additional extensions enabled through the `PrettyConfig` which are not in the set of default extensions are still included in the output RON. Therefore, this PR supersedes #339.
  c) This now enables programs which always use a set of extensions to enable them programmatically and exclude them from the RON config files.
4) This PR is fully backwards compatible by adding one extra method each to the `Serializer` and `Deserializer` and not changing the default behaviour (i.e. no default extensions).
5) This PR also does a tiny bit of cleanup in the docs and `Default` impl for `PrettyConfig`.

* [x] Add and update the documentation
* [x] I've included my change in `CHANGELOG.md`
