### PR TITLE
Fix #289 enumerate_arrays comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `unwrap_newtypes` extension during serialization ([#333](https://github.com/ron-rs/ron/pull/333))
 - Implement `unwrap_variant_newtypes` extension during serialization ([#336](https://github.com/ron-rs/ron/pull/336))
 - Fix issue [#338](https://github.com/ron-rs/ron/issues/338) value map roundtrip ([#341](https://github.com/ron-rs/ron/pull/341))
+- Fix issue [#289](https://github.com/ron-rs/ron/issues/289) enumerate_arrays comments ([#344](https://github.com/ron-rs/ron/pull/344))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -746,19 +746,19 @@ impl<'a, W: io::Write> ser::SerializeSeq for Compound<'a, W> {
             self.ser.output.write_all(b",")?;
             if let Some((ref config, ref mut pretty)) = self.ser.pretty {
                 if pretty.indent <= config.depth_limit {
-                    if config.enumerate_arrays {
-                        assert!(config.new_line.contains('\n'));
-                        let index = pretty.sequence_index.last_mut().unwrap();
-                        //TODO: when /**/ comments are supported, prepend the index
-                        // to an element instead of appending it.
-                        write!(self.ser.output, "// [{}]", index).unwrap();
-                        *index += 1;
-                    }
                     self.ser.output.write_all(config.new_line.as_bytes())?;
                 }
             }
         }
         self.ser.indent()?;
+
+        if let Some((ref mut config, ref mut pretty)) = self.ser.pretty {
+            if pretty.indent <= config.depth_limit && config.enumerate_arrays {
+                let index = pretty.sequence_index.last_mut().unwrap();
+                write!(self.ser.output, "/*[{}]*/ ", index)?;
+                *index += 1;
+            }
+        }
 
         value.serialize(&mut *self.ser)?;
 

--- a/tests/289_enumerate_arrays.rs
+++ b/tests/289_enumerate_arrays.rs
@@ -1,0 +1,27 @@
+const EXPTECTED: &str = "[
+    /*[0]*/ None,
+    /*[1]*/ Some([]),
+    /*[2]*/ Some([
+        /*[0]*/ 42,
+    ]),
+    /*[3]*/ Some([
+        /*[0]*/ 4,
+        /*[1]*/ 2,
+    ]),
+    /*[4]*/ None,
+]";
+
+#[test]
+fn enumerate_arrays() {
+    let v: Vec<Option<Vec<u8>>> = vec![None, Some(vec![]), Some(vec![42]), Some(vec![4, 2]), None];
+
+    let pretty = ron::ser::PrettyConfig::new().enumerate_arrays(true);
+
+    let ser = ron::ser::to_string_pretty(&v, pretty).unwrap();
+
+    assert_eq!(ser, EXPTECTED);
+
+    let de: Vec<Option<Vec<u8>>> = ron::from_str(&ser).unwrap();
+
+    assert_eq!(v, de)
+}


### PR DESCRIPTION
Fixes #289 and an associated `TODO` by moving the array index comments in front of the items using `/*[i]*/`.

* [x] I've included my change in `CHANGELOG.md`
