### PR TITLE
Guard `u128` and `i128` behind optional `integer128` feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,9 @@ jobs:
         with:
           command: update
           args: -p indexmap --precise 1.6.2
-      - run: cargo test --no-default-features
       - run: cargo test
+      - run: cargo test --features integer128
+      - run: cargo test --features indexmap
       - run: cargo test --all-features
 
   clippy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           command: update
           args: -p indexmap --precise 1.6.2
+      - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report struct name in expected struct error ([#342](https://github.com/ron-rs/ron/pull/342))
 - Add `Options` builder to configure the RON serde roundtrip ([#343](https://github.com/ron-rs/ron/pull/343))
 - Add `compact_arrays` ([#299](https://github.com/ron-rs/ron/pull/299)) and `separator` options to `PrettyConfig` ([#349](https://github.com/ron-rs/ron/pull/349))
+- Add `integer128` feature that guards `i128` and `u128` ([#304](https://github.com/ron-rs/ron/pull/304), [#351](https://github.com/ron-rs/ron/pull/351))
 
 ## [0.7.0] - 2021-10-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ repository = "https://github.com/ron-rs/ron"
 documentation = "https://docs.rs/ron/"
 exclude = ["bors.toml", ".travis.yml"]
 
+[features]
+default = ["integer128"]
+integer128 = []
+
 [dependencies]
 base64 = "0.13"
 bitflags = "=1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ documentation = "https://docs.rs/ron/"
 exclude = ["bors.toml", ".travis.yml"]
 
 [features]
-default = ["integer128"]
+default = []
 integer128 = []
 
 [dependencies]

--- a/src/de/id.rs
+++ b/src/de/id.rs
@@ -71,6 +71,7 @@ impl<'a, 'b: 'a, 'c> de::Deserializer<'b> for &'c mut IdDeserializer<'a, 'b> {
         unimplemented!("IdDeserializer may only be used for identifiers")
     }
 
+    #[cfg(feature = "integer128")]
     fn deserialize_i128<V>(self, _: V) -> Result<V::Value>
     where
         V: Visitor<'b>,
@@ -106,6 +107,7 @@ impl<'a, 'b: 'a, 'c> de::Deserializer<'b> for &'c mut IdDeserializer<'a, 'b> {
         unimplemented!("IdDeserializer may only be used for identifiers")
     }
 
+    #[cfg(feature = "integer128")]
     fn deserialize_u128<V>(self, _: V) -> Result<V::Value>
     where
         V: Visitor<'b>,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -182,7 +182,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                     AnyNum::U32(x) => visitor.visit_u32(x),
                     AnyNum::I64(x) => visitor.visit_i64(x),
                     AnyNum::U64(x) => visitor.visit_u64(x),
+                    #[cfg(feature = "integer128")]
                     AnyNum::I128(x) => visitor.visit_i128(x),
+                    #[cfg(feature = "integer128")]
                     AnyNum::U128(x) => visitor.visit_u128(x),
                 }
             }
@@ -228,6 +230,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         visitor.visit_i64(self.bytes.signed_integer()?)
     }
 
+    #[cfg(feature = "integer128")]
     fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
@@ -263,6 +266,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         visitor.visit_u64(self.bytes.unsigned_integer()?)
     }
 
+    #[cfg(feature = "integer128")]
     fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,

--- a/src/de/tag.rs
+++ b/src/de/tag.rs
@@ -71,6 +71,7 @@ impl<'a, 'b: 'a, 'c> de::Deserializer<'b> for &'c mut TagDeserializer<'a, 'b> {
         self.d.deserialize_i64(visitor)
     }
 
+    #[cfg(feature = "integer128")]
     fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'b>,
@@ -106,6 +107,7 @@ impl<'a, 'b: 'a, 'c> de::Deserializer<'b> for &'c mut TagDeserializer<'a, 'b> {
         self.d.deserialize_u64(visitor)
     }
 
+    #[cfg(feature = "integer128")]
     fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'b>,

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -56,6 +56,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Number(Number::new(v)))
     }
 
+    #[cfg(feature = "integer128")]
     fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
     where
         E: Error,
@@ -70,6 +71,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Number(Number::new(v)))
     }
 
+    #[cfg(feature = "integer128")]
     fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
     where
         E: Error,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -113,13 +113,13 @@ pub struct Bytes<'a> {
 }
 
 #[cfg(feature = "integer128")]
-pub(crate) type UInt = u128;
+pub(crate) type LargeUInt = u128;
 #[cfg(not(feature = "integer128"))]
-pub(crate) type UInt = u64;
+pub(crate) type LargeUInt = u64;
 #[cfg(feature = "integer128")]
-pub(crate) type SInt = i128;
+pub(crate) type LargeSInt = i128;
 #[cfg(not(feature = "integer128"))]
-pub(crate) type SInt = i64;
+pub(crate) type LargeSInt = i64;
 
 impl<'a> Bytes<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<Self> {
@@ -262,25 +262,25 @@ impl<'a> Bytes<'a> {
 
             any_float(f)
         } else {
-            let max_u8 = UInt::from(std::u8::MAX);
-            let max_u16 = UInt::from(std::u16::MAX);
-            let max_u32 = UInt::from(std::u32::MAX);
+            let max_u8 = LargeUInt::from(std::u8::MAX);
+            let max_u16 = LargeUInt::from(std::u16::MAX);
+            let max_u32 = LargeUInt::from(std::u32::MAX);
             #[cfg_attr(not(feature = "integer128"), allow(clippy::useless_conversion))]
-            let max_u64 = UInt::from(std::u64::MAX);
+            let max_u64 = LargeUInt::from(std::u64::MAX);
 
-            let min_i8 = SInt::from(std::i8::MIN);
-            let max_i8 = SInt::from(std::i8::MAX);
-            let min_i16 = SInt::from(std::i16::MIN);
-            let max_i16 = SInt::from(std::i16::MAX);
-            let min_i32 = SInt::from(std::i32::MIN);
-            let max_i32 = SInt::from(std::i32::MAX);
+            let min_i8 = LargeSInt::from(std::i8::MIN);
+            let max_i8 = LargeSInt::from(std::i8::MAX);
+            let min_i16 = LargeSInt::from(std::i16::MIN);
+            let max_i16 = LargeSInt::from(std::i16::MAX);
+            let min_i32 = LargeSInt::from(std::i32::MIN);
+            let max_i32 = LargeSInt::from(std::i32::MAX);
             #[cfg_attr(not(feature = "integer128"), allow(clippy::useless_conversion))]
-            let min_i64 = SInt::from(std::i64::MIN);
+            let min_i64 = LargeSInt::from(std::i64::MIN);
             #[cfg_attr(not(feature = "integer128"), allow(clippy::useless_conversion))]
-            let max_i64 = SInt::from(std::i64::MAX);
+            let max_i64 = LargeSInt::from(std::i64::MAX);
 
             if is_signed {
-                match self.signed_integer::<SInt>() {
+                match self.signed_integer::<LargeSInt>() {
                     Ok(x) => {
                         if x >= min_i8 && x <= max_i8 {
                             Ok(AnyNum::I8(x as i8))
@@ -308,7 +308,7 @@ impl<'a> Bytes<'a> {
                     }
                 }
             } else {
-                match self.unsigned_integer::<UInt>() {
+                match self.unsigned_integer::<LargeUInt>() {
                     Ok(x) => {
                         if x <= max_u8 {
                             Ok(AnyNum::U8(x as u8))

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -112,6 +112,15 @@ pub struct Bytes<'a> {
     line: usize,
 }
 
+#[cfg(feature = "integer128")]
+pub(crate) type UInt = u128;
+#[cfg(not(feature = "integer128"))]
+pub(crate) type UInt = u64;
+#[cfg(feature = "integer128")]
+pub(crate) type SInt = i128;
+#[cfg(not(feature = "integer128"))]
+pub(crate) type SInt = i64;
+
 impl<'a> Bytes<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<Self> {
         let mut b = Bytes {
@@ -253,15 +262,6 @@ impl<'a> Bytes<'a> {
 
             any_float(f)
         } else {
-            #[cfg(feature = "integer128")]
-            type UInt = u128;
-            #[cfg(not(feature = "integer128"))]
-            type UInt = u64;
-            #[cfg(feature = "integer128")]
-            type SInt = i128;
-            #[cfg(not(feature = "integer128"))]
-            type SInt = i64;
-
             let max_u8 = UInt::from(std::u8::MAX);
             let max_u16 = UInt::from(std::u16::MAX);
             let max_u32 = UInt::from(std::u32::MAX);

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -409,46 +409,103 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
-        self.serialize_i128(i128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_i128(i128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            self.serialize_i64(i64::from(v))
+        }
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
-        self.serialize_i128(i128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_i128(i128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            self.serialize_i64(i64::from(v))
+        }
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
-        self.serialize_i128(i128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_i128(i128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            self.serialize_i64(i64::from(v))
+        }
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
-        self.serialize_i128(i128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_i128(i128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            write!(self.output, "{}", v).map_err(From::from)
+        }
     }
 
+    #[cfg(feature = "integer128")]
     fn serialize_i128(self, v: i128) -> Result<()> {
         // TODO optimize
-        write!(self.output, "{}", v)?;
-        Ok(())
+        write!(self.output, "{}", v).map_err(From::from)
     }
 
     fn serialize_u8(self, v: u8) -> Result<()> {
-        self.serialize_u128(u128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_u128(u128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            self.serialize_u64(u64::from(v))
+        }
     }
 
     fn serialize_u16(self, v: u16) -> Result<()> {
-        self.serialize_u128(u128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_u128(u128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            self.serialize_u64(u64::from(v))
+        }
     }
 
     fn serialize_u32(self, v: u32) -> Result<()> {
-        self.serialize_u128(u128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_u128(u128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            self.serialize_u64(u64::from(v))
+        }
     }
 
     fn serialize_u64(self, v: u64) -> Result<()> {
-        self.serialize_u128(u128::from(v))
+        #[cfg(feature = "integer128")]
+        {
+            self.serialize_u128(u128::from(v))
+        }
+        #[cfg(not(feature = "integer128"))]
+        {
+            write!(self.output, "{}", v).map_err(From::from)
+        }
     }
 
+    #[cfg(feature = "integer128")]
     fn serialize_u128(self, v: u128) -> Result<()> {
-        write!(self.output, "{}", v)?;
-        Ok(())
+        // TODO optimize
+        write!(self.output, "{}", v).map_err(From::from)
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     error::{Error, Result},
     extensions::Extensions,
     options::Options,
-    parse::{is_ident_first_char, is_ident_other_char},
+    parse::{is_ident_first_char, is_ident_other_char, SInt, UInt},
 };
 
 #[cfg(test)]
@@ -375,6 +375,20 @@ impl<W: io::Write> Serializer<W> {
         Ok(())
     }
 
+    fn serialize_sint(&mut self, value: impl Into<SInt>) -> Result<()> {
+        // TODO optimize
+        write!(self.output, "{}", value.into())?;
+
+        Ok(())
+    }
+
+    fn serialize_uint(&mut self, value: impl Into<UInt>) -> Result<()> {
+        // TODO optimize
+        write!(self.output, "{}", value.into())?;
+
+        Ok(())
+    }
+
     fn write_identifier(&mut self, name: &str) -> io::Result<()> {
         let mut bytes = name.as_bytes().iter().cloned();
         if !bytes.next().map_or(false, is_ident_first_char) || !bytes.all(is_ident_other_char) {
@@ -409,103 +423,45 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_i128(i128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            self.serialize_i64(i64::from(v))
-        }
+        self.serialize_sint(v)
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_i128(i128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            self.serialize_i64(i64::from(v))
-        }
+        self.serialize_sint(v)
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_i128(i128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            self.serialize_i64(i64::from(v))
-        }
+        self.serialize_sint(v)
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_i128(i128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            write!(self.output, "{}", v).map_err(From::from)
-        }
+        self.serialize_sint(v)
     }
 
     #[cfg(feature = "integer128")]
     fn serialize_i128(self, v: i128) -> Result<()> {
-        // TODO optimize
-        write!(self.output, "{}", v).map_err(From::from)
+        self.serialize_sint(v)
     }
 
     fn serialize_u8(self, v: u8) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_u128(u128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            self.serialize_u64(u64::from(v))
-        }
+        self.serialize_uint(v)
     }
 
     fn serialize_u16(self, v: u16) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_u128(u128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            self.serialize_u64(u64::from(v))
-        }
+        self.serialize_uint(v)
     }
 
     fn serialize_u32(self, v: u32) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_u128(u128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            self.serialize_u64(u64::from(v))
-        }
+        self.serialize_uint(v)
     }
 
     fn serialize_u64(self, v: u64) -> Result<()> {
-        #[cfg(feature = "integer128")]
-        {
-            self.serialize_u128(u128::from(v))
-        }
-        #[cfg(not(feature = "integer128"))]
-        {
-            write!(self.output, "{}", v).map_err(From::from)
-        }
+        self.serialize_uint(v)
     }
 
     #[cfg(feature = "integer128")]
     fn serialize_u128(self, v: u128) -> Result<()> {
-        // TODO optimize
-        write!(self.output, "{}", v).map_err(From::from)
+        self.serialize_uint(v)
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     error::{Error, Result},
     extensions::Extensions,
     options::Options,
-    parse::{is_ident_first_char, is_ident_other_char, SInt, UInt},
+    parse::{is_ident_first_char, is_ident_other_char, LargeSInt, LargeUInt},
 };
 
 #[cfg(test)]
@@ -375,14 +375,14 @@ impl<W: io::Write> Serializer<W> {
         Ok(())
     }
 
-    fn serialize_sint(&mut self, value: impl Into<SInt>) -> Result<()> {
+    fn serialize_sint(&mut self, value: impl Into<LargeSInt>) -> Result<()> {
         // TODO optimize
         write!(self.output, "{}", value.into())?;
 
         Ok(())
     }
 
-    fn serialize_uint(&mut self, value: impl Into<UInt>) -> Result<()> {
+    fn serialize_uint(&mut self, value: impl Into<LargeUInt>) -> Result<()> {
         // TODO optimize
         write!(self.output, "{}", value.into())?;
 

--- a/tests/min_max.rs
+++ b/tests/min_max.rs
@@ -32,6 +32,7 @@ fn test_i64_max() {
     );
 }
 
+#[cfg(feature = "integer128")]
 #[test]
 fn test_i128_min() {
     assert_eq!(
@@ -40,6 +41,7 @@ fn test_i128_min() {
     );
 }
 
+#[cfg(feature = "integer128")]
 #[test]
 fn test_i128_max() {
     assert_eq!(
@@ -48,6 +50,7 @@ fn test_i128_max() {
     );
 }
 
+#[cfg(feature = "integer128")]
 #[test]
 fn test_u128_min() {
     assert_eq!(
@@ -56,6 +59,7 @@ fn test_u128_min() {
     );
 }
 
+#[cfg(feature = "integer128")]
 #[test]
 fn test_u128_max() {
     assert_eq!(

--- a/tests/struct_integers.rs
+++ b/tests/struct_integers.rs
@@ -6,11 +6,13 @@ struct S {
     b: i16,
     c: i32,
     d: i64,
+    #[cfg(feature = "integer128")]
     e: i128,
     f: u8,
     g: u16,
     h: u32,
     i: u64,
+    #[cfg(feature = "integer128")]
     j: u128,
 }
 
@@ -21,11 +23,13 @@ fn roundtrip() {
         b: std::i16::MIN,
         c: std::i32::MIN,
         d: std::i64::MIN,
+        #[cfg(feature = "integer128")]
         e: std::i128::MIN,
         f: std::u8::MAX,
         g: std::u16::MAX,
         h: std::u32::MAX,
         i: std::u64::MAX,
+        #[cfg(feature = "integer128")]
         j: std::u128::MAX,
     };
     let serialized = ron::ser::to_string(&s).unwrap();


### PR DESCRIPTION
This PR adds an optional `integer128` feature that guards the usage of `i128` and `u128`. Therefore, any library using `serde` with either of these types should now enable the feature. This PR is heavily inspired by #304.

* [x] I've included my change in `CHANGELOG.md`
