### PR TITLE
Fix #265 with better missing comma detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Options` builder to configure the RON serde roundtrip ([#343](https://github.com/ron-rs/ron/pull/343))
 - Add `compact_arrays` ([#299](https://github.com/ron-rs/ron/pull/299)) and `separator` options to `PrettyConfig` ([#349](https://github.com/ron-rs/ron/pull/349))
 - Add `integer128` feature that guards `i128` and `u128` ([#304](https://github.com/ron-rs/ron/pull/304), [#351](https://github.com/ron-rs/ron/pull/351))
+- Fix issue [#265](https://github.com/ron-rs/ron/issues/265) with better missing comma error ([#353](https://github.com/ron-rs/ron/pull/353))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -588,7 +588,17 @@ impl<'a, 'de> CommaSeparated<'a, 'de> {
     fn has_element(&mut self) -> Result<bool> {
         self.de.bytes.skip_ws()?;
 
-        Ok(self.had_comma && self.de.bytes.peek_or_eof()? != self.terminator)
+        match (
+            self.had_comma,
+            self.de.bytes.peek_or_eof()? != self.terminator,
+        ) {
+            // Trailing comma, maybe has a next element
+            (true, has_element) => Ok(has_element),
+            // No trailing comma but terminator
+            (false, false) => Ok(false),
+            // No trailing comma or terminator
+            (false, true) => self.err(ErrorCode::ExpectedComma),
+        }
     }
 }
 

--- a/tests/256_comma_error.rs
+++ b/tests/256_comma_error.rs
@@ -1,0 +1,70 @@
+use ron::error::{Error, ErrorCode, Position};
+
+#[derive(Debug, serde::Deserialize)]
+struct Test {
+    a: i32,
+    b: i32,
+}
+
+#[test]
+fn test_missing_comma_error() {
+    let tuple_string = r#"(
+        1 // <-- forgotten comma here
+        2
+    )"#;
+
+    assert_eq!(
+        ron::from_str::<(i32, i32)>(tuple_string).unwrap_err(),
+        Error {
+            code: ErrorCode::ExpectedComma,
+            position: Position { line: 3, col: 9 }
+        }
+    );
+
+    let list_string = r#"[
+        0,
+        1 // <-- forgotten comma here
+        2
+    ]"#;
+
+    assert_eq!(
+        ron::from_str::<Vec<i32>>(list_string).unwrap_err(),
+        Error {
+            code: ErrorCode::ExpectedComma,
+            position: Position { line: 4, col: 9 }
+        }
+    );
+
+    let struct_string = r#"Test(
+        a: 1 // <-- forgotten comma here
+        b: 2
+    )"#;
+
+    assert_eq!(
+        ron::from_str::<Test>(struct_string).unwrap_err(),
+        Error {
+            code: ErrorCode::ExpectedComma,
+            position: Position { line: 3, col: 9 }
+        }
+    );
+
+    let map_string = r#"{
+        "a": 1 // <-- forgotten comma here
+        "b": 2
+    }"#;
+
+    assert_eq!(
+        ron::from_str::<std::collections::HashMap<String, i32>>(map_string).unwrap_err(),
+        Error {
+            code: ErrorCode::ExpectedComma,
+            position: Position { line: 3, col: 9 }
+        }
+    );
+}
+
+#[test]
+fn test_comma_end() {
+    assert_eq!(ron::from_str::<(i32, i32)>("(0, 1)").unwrap(), (0, 1));
+    assert_eq!(ron::from_str::<(i32, i32)>("(0, 1,)").unwrap(), (0, 1));
+    assert_eq!(ron::from_str::<()>("()").unwrap(), ());
+}


### PR DESCRIPTION
Fix #265 by better dealing with missing comma in `CommaSeparated` so that an `ExpectedComma` error can be reported.

* [x] I've included my change in `CHANGELOG.md`
