### PR TITLE
Fixed serialization for floating point values less than EPSILON.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue [#203](https://github.com/ron-rs/ron/issues/203) with full de error positioning ([#356](https://github.com/ron-rs/ron/pull/356))
 - Fix issue [#367](https://github.com/ron-rs/ron/issues/367) with eager implicit some ([#368](https://github.com/ron-rs/ron/pull/368))
 - Fix issue [#370](https://github.com/ron-rs/ron/issues/370) with `FromStr`-equivalent float EBNF and `Error::FloatUnderscore` ([#371](https://github.com/ron-rs/ron/pull/371))
+- Fix issue [#374](https://github.com/ron-rs/ron/issues/374) extraneous .0 for small floats ([#372](https://github.com/ron-rs/ron/pull/372))
 
 ## [0.7.0] - 2021-10-22
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -443,7 +443,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
 
     fn serialize_f32(self, v: f32) -> Result<()> {
         write!(self.output, "{}", v)?;
-        if (v - v.floor()).abs() < f32::EPSILON {
+        if v.fract() == 0.0 {
             write!(self.output, ".0")?;
         }
         Ok(())
@@ -451,7 +451,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
 
     fn serialize_f64(self, v: f64) -> Result<()> {
         write!(self.output, "{}", v)?;
-        if (v - v.floor()).abs() < f64::EPSILON {
+        if v.fract() == 0.0 {
             write!(self.output, ".0")?;
         }
         Ok(())

--- a/tests/floats.rs
+++ b/tests/floats.rs
@@ -17,4 +17,7 @@ fn decimal_floats() {
 
     let with_pretty = to_string_pretty(&1.0, PrettyConfig::new()).unwrap();
     assert_eq!(with_pretty, "1.0");
+
+    let tiny_pretty = to_string_pretty(&0.00000000000000005, PrettyConfig::new()).unwrap();
+    assert_eq!(tiny_pretty, "0.00000000000000005");
 }


### PR DESCRIPTION
Since `EPSILON` is defined as the difference between 1 and the next highest value, and values close to zero have higher precision, very small values were serialized with an extra ".0" e.g. "0.00000000000000005.0". These values then can't be properly deserialized. This fix compares the fractional part of the float to 0.0 instead of using `EPSILON`.

Fixes #374.

- [ ] I've included my change in `CHANGELOG.md`