### PR TITLE
Fix \0 in string on nightly + enable weekly CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
     branches:
     - master
     - 'v*.*'
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   tests:

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -811,6 +811,7 @@ impl<'a> Bytes<'a> {
             b'n' => '\n',
             b'r' => '\r',
             b't' => '\t',
+            b'0' => '\0',
             b'x' => self.decode_ascii_escape()? as char,
             b'u' => {
                 self.expect_byte(b'{', Error::InvalidEscape("Missing { in Unicode escape"))?;

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -66,5 +66,12 @@ fn test_chars() {
 
 #[test]
 fn test_nul_in_string() {
+    assert_eq!(
+        from_str("\"Hello\0World!\""),
+        Ok(String::from("Hello\0World!"))
+    );
+
     check_same("Hello\0World!".to_owned());
+    check_same("Hello\x00World!".to_owned());
+    check_same("Hello\u{0}World!".to_owned());
 }


### PR DESCRIPTION
Add the `\0` special case to escape character handling to fix parsing it on nightly tests.

Also enables CI tests on every Sunday at midnight to catch nightly failures in quiet times.

~~* [ ] I've included my change in `CHANGELOG.md`~~
