### PR TITLE
added missing whitespace to named_field

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -126,7 +126,7 @@ tuple = "(", [value, { comma, value }, [comma]], ")";
 struct = unit_struct | tuple_struct | named_struct;
 unit_struct = ident | "()";
 tuple_struct = [ident], ws, tuple;
-named_struct = [ident], ws, "(", [named_field, { comma, named_field }, [comma]], ")";
+named_struct = [ident], ws, "(", ws, [named_field, { comma, named_field }, [comma]], ")";
 named_field = ident, ws, ":", ws, value;
 ```
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -127,7 +127,7 @@ struct = unit_struct | tuple_struct | named_struct;
 unit_struct = ident | "()";
 tuple_struct = [ident], ws, tuple;
 named_struct = [ident], ws, "(", [named_field, { comma, named_field }, [comma]], ")";
-named_field = ident, ws, ":", value;
+named_field = ident, ws, ":", ws, value;
 ```
 
 ## Enum


### PR DESCRIPTION
not 100% sure but i think named_field should allow whitespace after the colon and before the value in the EBNF