### PR TITLE
Limit indexmap version to < 1.9 to support 1.46 MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ integer128 = []
 [dependencies]
 base64 = "0.13"
 bitflags = "1.0.4"
-indexmap = { version = "1.0.2", features = ["serde-1"], optional = true }
+# Memo: remove upper version limit once MSRV >= 1.56.0
+indexmap = { version = ">= 1.0.2, < 1.9", features = ["serde-1"], optional = true }
 serde = { version = "1.0.60", features = ["serde_derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #383

~~* [ ] I've included my change in `CHANGELOG.md`~~
