### PR TITLE
Upper-bound dependencies to compile with MSRV 1.36

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,18 +27,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1
-        name: Downgrade bitflags to MSRV
-        if: ${{ matrix.rust }} == "1.36.0"
-        with:
-          command: update
-          args: -p bitflags --precise 1.2.1
-      - uses: actions-rs/cargo@v1
-        name: Downgrade indexmap to MSRV
-        if: ${{ matrix.rust }} == "1.36.0"
-        with:
-          command: update
-          args: -p indexmap --precise 1.6.2
       - run: cargo test
       - run: cargo test --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ name = "ron"
 
 [dependencies]
 base64 = "0.13"
-bitflags = "1.0.4"
-indexmap = { version = "1.0.2", features = ["serde-1"], optional = true }
+bitflags = ">= 1.0.4, < 1.3"
+indexmap = { version = ">= 1.0.2, < 1.7", features = ["serde-1"], optional = true }
 serde = { version = "1.0.60", features = ["serde_derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This is an example of how we could set upper version bounds for the published 0.7 version to work with its MSRV 1.36 without requiring fixes by the user.

* [ ] I've included my change in `CHANGELOG.md`
