### PR TITLE
Add ci caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup Rust Environment
+
+inputs:
+  key:
+    description: Cache key
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ inputs.key }}-cargo-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
           profile: minimal
           components: llvm-tools-preview
           override: true
-      - run: cargo install grcov --locked
+      - run: cargo install grcov --force --locked
       - run: |
           cargo test --all-features --all-targets
           grcov . -s . --binary-path ./target/debug/ \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,16 @@ jobs:
         rust: [1.46.0, stable, nightly]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -43,7 +52,16 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -58,7 +76,16 @@ jobs:
     name: "Format: stable"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -71,7 +98,16 @@ jobs:
     name: "Coverage: nightly"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: test-${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -61,7 +61,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: clippy-stable-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -85,7 +85,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: rustfmt-stable-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -107,7 +107,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: coverage-nightly-cargo-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/setup
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: test-${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: test-${{ matrix.rust }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -53,15 +47,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/setup
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: clippy-stable-cargo-${{ hashFiles('Cargo.lock') }}
+          key: clippy-stable
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -77,15 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/setup
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: rustfmt-stable-cargo-${{ hashFiles('Cargo.lock') }}
+          key: rustfmt-stable
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -99,15 +81,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/setup
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: coverage-nightly-cargo-${{ hashFiles('Cargo.lock') }}
+          key: coverage-nightly
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
           profile: minimal
           components: llvm-tools-preview
           override: true
-      - run: cargo install grcov --force
+      - run: cargo install grcov --locked
       - run: |
           cargo test --all-features --all-targets
           grcov . -s . --binary-path ./target/debug/ \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
           profile: minimal
           components: llvm-tools-preview
           override: true
-      - run: cargo install grcov --force --locked
+      - run: cargo install grcov --force
       - run: |
           cargo test --all-features --all-targets
           grcov . -s . --binary-path ./target/debug/ \


### PR DESCRIPTION
This adds "official" [cargo caching](https://github.com/actions/cache/blob/main/examples.md#rust---cargo) to cut CI time (from ~3 mins to ~1 mins). We also bump the version of github's checkout action to the latest.

![Screenshot from 2022-06-26 06-50-17](https://user-images.githubusercontent.com/18283/175811628-192f2470-1491-4abe-a04b-07fa9b1dc933.png)
to
![Screenshot from 2022-06-26 07-20-56](https://user-images.githubusercontent.com/18283/175811662-396e28a8-f2ba-4768-9fa6-c4c256e9417a.png)

Note that the codecov run failures are just because I don't have access to the api of course. If preferred, I can extract/isolate the cache & toolchain steps into a shared local action that this imports, [similar to askama's](https://github.com/djc/askama/blob/main/.github/actions/setup/action.yml).

* [ ] I've included my change in `CHANGELOG.md`
