### PR TITLE
add target dir for code coverage job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
         with:
-          key: coverage-nightly
+          key: coverage
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -91,6 +91,8 @@ jobs:
           components: llvm-tools-preview
           override: true
       - run: cargo install grcov --force --locked
+        env:
+          CARGO_TARGET_DIR: target/
       - run: |
           cargo test --all-features --all-targets
           grcov . -s . --binary-path ./target/debug/ \


### PR DESCRIPTION
Using alternative install directory that should be caught up in the caching (`CACHE_TARGET_DIR` envvar mentioned [here](https://doc.rust-lang.org/cargo/reference/environment-variables.html)). 

This also removes `nightly` from the cache key to blow out the cache (since I believe this change doesn't affect the cargo.lock sha). IMHO the disambiguation isn't necessary (don't imagine coverage will ever run from a matrix of rust versions).

~~* [ ] I've included my change in `CHANGELOG.md`~~
