### PR TITLE
Improve error information for serde errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue [#301](https://github.com/ron-rs/ron/issues/301) with better error messages ([#354](https://github.com/ron-rs/ron/pull/354))
 - Fix issue [#337](https://github.com/ron-rs/ron/issues/337) by removing `decimal_floats` PrettyConfig option and unconditional decimals in floats ([#363](https://github.com/ron-rs/ron/pull/363))
 - Fix issue [#203](https://github.com/ron-rs/ron/issues/203) with full de error positioning ([#356](https://github.com/ron-rs/ron/pull/356))
+- Expand the `ron::Error` enum to distinguish `serde` errors like `NoSuchEnumVariant` and `MissingStructField` with error positioning ([#394](https://github.com/ron-rs/ron/pull/394))
 - Bump MSRV to 1.56.0 ([#396](https://github.com/ron-rs/ron/pull/396))
 
 ## [0.7.1] - 2022-06-15

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,29 @@ pub enum Error {
 
     Utf8Error(Utf8Error),
     TrailingCharacters,
+
+    ExpectedDifferentType {
+        expected: String,
+        found: UnexpectedSerdeTypeValue,
+    },
+    InvalidValueForType {
+        expected: String,
+        found: UnexpectedSerdeTypeValue,
+    },
+    ExpectedDifferentLength {
+        expected: String,
+        found: usize,
+    },
+    NoSuchEnumVariant {
+        expected: &'static [&'static str],
+        found: String,
+    },
+    NoSuchStructField {
+        expected: &'static [&'static str],
+        found: String,
+    },
+    MissingStructField(&'static str),
+    DuplicateStructField(&'static str),
 }
 
 impl fmt::Display for SpannedError {
@@ -97,10 +120,10 @@ impl fmt::Display for Error {
             Error::ExpectedDifferentStructName {
                 expected,
                 ref found,
-            } => write!(f, "Expected struct '{}' but found '{}'", expected, found),
+            } => write!(f, "Expected struct `{}` but found `{}`", expected, found),
             Error::ExpectedStructLike => f.write_str("Expected opening `(`"),
             Error::ExpectedNamedStructLike(name) => {
-                write!(f, "Expected opening `(` for struct '{}'", name)
+                write!(f, "Expected opening `(` for struct `{}`", name)
             }
             Error::ExpectedStructLikeEnd => f.write_str("Expected closing `)`"),
             Error::ExpectedUnit => f.write_str("Expected unit"),
@@ -109,7 +132,7 @@ impl fmt::Display for Error {
             Error::ExpectedIdentifier => f.write_str("Expected identifier"),
             Error::InvalidEscape(s) => f.write_str(s),
             Error::IntegerOutOfBounds => f.write_str("Integer is out of bounds"),
-            Error::NoSuchExtension(ref name) => write!(f, "No RON extension named '{}'", name),
+            Error::NoSuchExtension(ref name) => write!(f, "No RON extension named `{}`", name),
             Error::Utf8Error(ref e) => fmt::Display::fmt(e, f),
             Error::UnclosedBlockComment => f.write_str("Unclosed block comment"),
             Error::UnderscoreAtBeginning => {
@@ -117,6 +140,70 @@ impl fmt::Display for Error {
             }
             Error::UnexpectedByte(ref byte) => write!(f, "Unexpected byte {:?}", byte),
             Error::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
+            Error::ExpectedDifferentType {
+                ref expected,
+                ref found,
+            } => {
+                write!(
+                    f,
+                    "Expected a value of type {} but found {} instead",
+                    expected, found
+                )
+            }
+            Error::InvalidValueForType {
+                ref expected,
+                ref found,
+            } => {
+                write!(f, "Expected {} but found {} instead", expected, found)
+            }
+            Error::ExpectedDifferentLength {
+                ref expected,
+                found,
+            } => {
+                write!(f, "Expected {} but found ", expected)?;
+
+                match found {
+                    0 => f.write_str("zero elements")?,
+                    1 => f.write_str("one element")?,
+                    n => write!(f, "{} elements", n)?,
+                }
+
+                f.write_str(" instead")
+            }
+            Error::NoSuchEnumVariant {
+                expected,
+                ref found,
+            } => {
+                write!(
+                    f,
+                    "Unexpected enum variant named `{}`, {}",
+                    found,
+                    OneOf {
+                        alts: expected,
+                        none: "variants"
+                    }
+                )
+            }
+            Error::NoSuchStructField {
+                expected,
+                ref found,
+            } => {
+                write!(
+                    f,
+                    "Unexpected field named `{}`, {}",
+                    found,
+                    OneOf {
+                        alts: expected,
+                        none: "fields"
+                    }
+                )
+            }
+            Error::MissingStructField(field) => {
+                write!(f, "Unexpected missing field `{}`", field)
+            }
+            Error::DuplicateStructField(field) => {
+                write!(f, "Unexpected duplicate field `{}`", field)
+            }
         }
     }
 }
@@ -134,14 +221,66 @@ impl fmt::Display for Position {
 }
 
 impl ser::Error for Error {
+    #[cold]
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::Message(msg.to_string())
     }
 }
 
 impl de::Error for Error {
+    #[cold]
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::Message(msg.to_string())
+    }
+
+    #[cold]
+    fn invalid_type(unexp: de::Unexpected, exp: &dyn de::Expected) -> Self {
+        Error::ExpectedDifferentType {
+            expected: exp.to_string(),
+            found: unexp.into(),
+        }
+    }
+
+    #[cold]
+    fn invalid_value(unexp: de::Unexpected, exp: &dyn de::Expected) -> Self {
+        Error::InvalidValueForType {
+            expected: exp.to_string(),
+            found: unexp.into(),
+        }
+    }
+
+    #[cold]
+    fn invalid_length(len: usize, exp: &dyn de::Expected) -> Self {
+        Error::ExpectedDifferentLength {
+            expected: exp.to_string(),
+            found: len,
+        }
+    }
+
+    #[cold]
+    fn unknown_variant(variant: &str, expected: &'static [&'static str]) -> Self {
+        Error::NoSuchEnumVariant {
+            expected,
+            found: variant.to_string(),
+        }
+    }
+
+    #[cold]
+    fn unknown_field(field: &str, expected: &'static [&'static str]) -> Self {
+        Error::NoSuchStructField {
+            expected,
+            found: field.to_string(),
+        }
+    }
+
+    #[cold]
+    fn missing_field(field: &'static str) -> Self {
+        Error::MissingStructField(field)
+    }
+
+    #[cold]
+    fn duplicate_field(field: &'static str) -> Self {
+        Error::DuplicateStructField(field)
     }
 }
 
@@ -178,5 +317,113 @@ impl From<io::Error> for SpannedError {
 impl From<SpannedError> for Error {
     fn from(e: SpannedError) -> Self {
         e.code
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum UnexpectedSerdeTypeValue {
+    Bool(bool),
+    Unsigned(u64),
+    Signed(i64),
+    Float(f64),
+    Char(char),
+    Str(String),
+    Bytes(Vec<u8>),
+    Unit,
+    Option,
+    NewtypeStruct,
+    Seq,
+    Map,
+    Enum,
+    UnitVariant,
+    NewtypeVariant,
+    TupleVariant,
+    StructVariant,
+    Other(String),
+}
+
+impl<'a> From<de::Unexpected<'a>> for UnexpectedSerdeTypeValue {
+    fn from(unexpected: de::Unexpected<'a>) -> Self {
+        use de::Unexpected::*;
+
+        match unexpected {
+            Bool(b) => Self::Bool(b),
+            Unsigned(u) => Self::Unsigned(u),
+            Signed(s) => Self::Signed(s),
+            Float(f) => Self::Float(f),
+            Char(c) => Self::Char(c),
+            Str(s) => Self::Str(s.to_owned()),
+            Bytes(b) => Self::Bytes(b.to_owned()),
+            Unit => Self::Unit,
+            Option => Self::Option,
+            NewtypeStruct => Self::NewtypeStruct,
+            Seq => Self::Seq,
+            Map => Self::Map,
+            Enum => Self::Enum,
+            UnitVariant => Self::UnitVariant,
+            NewtypeVariant => Self::NewtypeVariant,
+            TupleVariant => Self::TupleVariant,
+            StructVariant => Self::StructVariant,
+            Other(o) => Self::Other(o.to_owned()),
+        }
+    }
+}
+
+impl fmt::Display for UnexpectedSerdeTypeValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::UnexpectedSerdeTypeValue::*;
+
+        match *self {
+            Bool(b) => write!(f, "the boolean `{}`", b),
+            Unsigned(i) => write!(f, "the integer `{}`", i),
+            Signed(i) => write!(f, "the integer `{}`", i),
+            Float(n) => write!(f, "the floating point number `{}`", n),
+            Char(c) => write!(f, "the UTF-8 character `{}`", c),
+            Str(ref s) => write!(f, "the string {:?}", s),
+            Bytes(ref b) => {
+                f.write_str("the bytes b\"")?;
+
+                for b in b {
+                    write!(f, "\\x{:02x}", b)?;
+                }
+
+                f.write_str("\"")
+            }
+            Unit => write!(f, "a unit value"),
+            Option => write!(f, "an optional value"),
+            NewtypeStruct => write!(f, "a newtype struct"),
+            Seq => write!(f, "a sequence"),
+            Map => write!(f, "a map"),
+            Enum => write!(f, "an enum"),
+            UnitVariant => write!(f, "a unit variant"),
+            NewtypeVariant => write!(f, "a newtype variant"),
+            TupleVariant => write!(f, "a tuple variant"),
+            StructVariant => write!(f, "a struct variant"),
+            Other(ref other) => f.write_str(other),
+        }
+    }
+}
+
+struct OneOf {
+    alts: &'static [&'static str],
+    none: &'static str,
+}
+
+impl fmt::Display for OneOf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.alts {
+            [] => write!(f, "there are no {}", self.none),
+            [a1] => write!(f, "expected `{}` instead", a1),
+            [a1, a2] => write!(f, "expected either `{}` or `{}` instead", a1, a2),
+            [a1, ref alts @ ..] => {
+                write!(f, "expected one of `{}`", a1)?;
+
+                for alt in alts {
+                    write!(f, ", `{}`", alt)?;
+                }
+
+                f.write_str(" instead")
+            }
+        }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -656,11 +656,11 @@ impl<'a> Bytes<'a> {
     }
 
     pub fn peek(&self) -> Option<u8> {
-        self.bytes.get(0).cloned()
+        self.bytes.first().cloned()
     }
 
     pub fn peek_or_eof(&self) -> Result<u8> {
-        self.bytes.get(0).cloned().ok_or(Error::Eof)
+        self.bytes.first().cloned().ok_or(Error::Eof)
     }
 
     pub fn signed_integer<T>(&mut self) -> Result<T>

--- a/tests/203_error_positions.rs
+++ b/tests/203_error_positions.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use ron::error::{Error, Position, SpannedError, UnexpectedSerdeTypeValue};
+use ron::error::{Error, Position, SpannedError};
 use serde::{
     de::{Deserialize, Error as DeError, Unexpected},
     Deserializer,
@@ -27,9 +27,9 @@ fn test_error_positions() {
     assert_eq!(
         ron::from_str::<TypeError>("  ()"),
         Err(SpannedError {
-            code: Error::ExpectedDifferentType {
+            code: Error::InvalidValueForType {
                 expected: String::from("impossible"),
-                found: UnexpectedSerdeTypeValue::Unit,
+                found: String::from("a unit value"),
             },
             position: Position { line: 1, col: 3 },
         })
@@ -40,7 +40,7 @@ fn test_error_positions() {
         Err(SpannedError {
             code: Error::InvalidValueForType {
                 expected: String::from("a nonzero u32"),
-                found: UnexpectedSerdeTypeValue::Unsigned(0),
+                found: String::from("the unsigned integer `0`"),
             },
             position: Position { line: 1, col: 28 },
         })

--- a/tests/203_error_positions.rs
+++ b/tests/203_error_positions.rs
@@ -63,6 +63,7 @@ fn test_error_positions() {
             code: Error::NoSuchEnumVariant {
                 expected: &["TupleVariant", "StructVariant"],
                 found: String::from("NotAVariant"),
+                outer: Some(String::from("Test")),
             },
             position: Position { line: 1, col: 12 },
         })
@@ -74,6 +75,7 @@ fn test_error_positions() {
             code: Error::NoSuchStructField {
                 expected: &["a", "b", "c"],
                 found: String::from("d"),
+                outer: Some(String::from("StructVariant")),
             },
             position: Position { line: 1, col: 39 },
         })
@@ -82,7 +84,10 @@ fn test_error_positions() {
     assert_eq!(
         ron::from_str::<Test>("StructVariant(a: true, c: -42)"),
         Err(SpannedError {
-            code: Error::MissingStructField("b"),
+            code: Error::MissingStructField {
+                field: "b",
+                outer: Some(String::from("StructVariant")),
+            },
             position: Position { line: 1, col: 30 },
         })
     );
@@ -90,7 +95,10 @@ fn test_error_positions() {
     assert_eq!(
         ron::from_str::<Test>("StructVariant(a: true, b: 1, a: false, c: -42)"),
         Err(SpannedError {
-            code: Error::DuplicateStructField("a"),
+            code: Error::DuplicateStructField {
+                field: "a",
+                outer: Some(String::from("StructVariant")),
+            },
             position: Position { line: 1, col: 31 },
         })
     );

--- a/tests/359_deserialize_seed.rs
+++ b/tests/359_deserialize_seed.rs
@@ -47,9 +47,9 @@ fn test_deserialize_seed() {
     assert_eq!(
         ron::Options::default().from_str_seed("'a'", Seed(42)),
         Err(ron::error::SpannedError {
-            code: ron::Error::ExpectedDifferentType {
+            code: ron::Error::InvalidValueForType {
                 expected: String::from("an integer"),
-                found: ron::error::UnexpectedSerdeTypeValue::Str(String::from("a")),
+                found: String::from("the string \"a\""),
             },
             position: ron::error::Position { line: 1, col: 4 },
         })

--- a/tests/359_deserialize_seed.rs
+++ b/tests/359_deserialize_seed.rs
@@ -47,9 +47,10 @@ fn test_deserialize_seed() {
     assert_eq!(
         ron::Options::default().from_str_seed("'a'", Seed(42)),
         Err(ron::error::SpannedError {
-            code: ron::Error::Message(String::from(
-                "invalid type: string \"a\", expected an integer"
-            )),
+            code: ron::Error::ExpectedDifferentType {
+                expected: String::from("an integer"),
+                found: ron::error::UnexpectedSerdeTypeValue::Str(String::from("a")),
+            },
             position: ron::error::Position { line: 1, col: 4 },
         })
     );

--- a/tests/393_serde_errors.rs
+++ b/tests/393_serde_errors.rs
@@ -1,0 +1,146 @@
+use ron::error::{Error, Position, SpannedError};
+
+#[derive(Debug, serde::Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+enum TestEnum {
+    StructVariant { a: bool, b: char, c: i32 },
+    NewtypeVariant(TestStruct),
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct TestStruct {
+    a: bool,
+    b: char,
+    c: i32,
+}
+
+#[test]
+fn test_unknown_enum_variant() {
+    assert_eq!(
+        ron::from_str::<TestEnum>("NotAVariant"),
+        Err(SpannedError {
+            code: Error::NoSuchEnumVariant {
+                expected: &["StructVariant", "NewtypeVariant"],
+                found: String::from("NotAVariant"),
+                outer: Some(String::from("TestEnum")),
+            },
+            position: Position { line: 1, col: 12 },
+        })
+    );
+}
+
+#[test]
+fn test_struct_enum_fields() {
+    assert_eq!(
+        ron::from_str::<TestEnum>("StructVariant(a: true, b: 'b', c: -42, d: \"gotcha\")"),
+        Err(SpannedError {
+            code: Error::NoSuchStructField {
+                expected: &["a", "b", "c"],
+                found: String::from("d"),
+                outer: Some(String::from("StructVariant")),
+            },
+            position: Position { line: 1, col: 41 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<TestEnum>("StructVariant(a: true, c: -42)"),
+        Err(SpannedError {
+            code: Error::MissingStructField {
+                field: "b",
+                outer: Some(String::from("StructVariant")),
+            },
+            position: Position { line: 1, col: 30 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<TestEnum>("StructVariant(a: true, b: 'b', a: false, c: -42)"),
+        Err(SpannedError {
+            code: Error::DuplicateStructField {
+                field: "a",
+                outer: Some(String::from("StructVariant")),
+            },
+            position: Position { line: 1, col: 33 },
+        })
+    );
+}
+
+#[test]
+fn test_newtype_enum_fields() {
+    assert_eq!(
+        ron::from_str::<TestEnum>("#![enable(unwrap_variant_newtypes)] NewtypeVariant(a: true, b: 'b', c: -42, d: \"gotcha\")"),
+        Err(SpannedError {
+            code: Error::NoSuchStructField {
+                expected: &["a", "b", "c"],
+                found: String::from("d"),
+                outer: Some(String::from("NewtypeVariant")),
+            },
+            position: Position { line: 1, col: 78 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<TestEnum>(
+            "#![enable(unwrap_variant_newtypes)] NewtypeVariant(a: true, c: -42)"
+        ),
+        Err(SpannedError {
+            code: Error::MissingStructField {
+                field: "b",
+                outer: Some(String::from("NewtypeVariant")),
+            },
+            position: Position { line: 1, col: 67 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<TestEnum>(
+            "#![enable(unwrap_variant_newtypes)] NewtypeVariant(a: true, b: 'b', a: false, c: -42)"
+        ),
+        Err(SpannedError {
+            code: Error::DuplicateStructField {
+                field: "a",
+                outer: Some(String::from("NewtypeVariant")),
+            },
+            position: Position { line: 1, col: 70 },
+        })
+    );
+}
+
+#[test]
+fn test_struct_fields() {
+    assert_eq!(
+        ron::from_str::<TestStruct>("TestStruct(a: true, b: 'b', c: -42, d: \"gotcha\")"),
+        Err(SpannedError {
+            code: Error::NoSuchStructField {
+                expected: &["a", "b", "c"],
+                found: String::from("d"),
+                outer: Some(String::from("TestStruct")),
+            },
+            position: Position { line: 1, col: 38 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<TestStruct>("TestStruct(a: true, c: -42)"),
+        Err(SpannedError {
+            code: Error::MissingStructField {
+                field: "b",
+                outer: Some(String::from("TestStruct")),
+            },
+            position: Position { line: 1, col: 27 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<TestStruct>("TestStruct(a: true, b: 'b', a: false, c: -42)"),
+        Err(SpannedError {
+            code: Error::DuplicateStructField {
+                field: "a",
+                outer: Some(String::from("TestStruct")),
+            },
+            position: Position { line: 1, col: 30 },
+        })
+    );
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -82,7 +82,7 @@ fn roundtrip_pretty() {
 
 #[test]
 fn roundtrip_sep_tuple_members() {
-    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    #[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
     pub enum FileOrMem {
         File(String),
         Memory,


### PR DESCRIPTION
Followup to #393

Adds explicit variants in `ron::Error` for `serde` errors from [`serde::de::Error`](https://docs.rs/serde/latest/serde/de/trait.Error.html) (`serde::ser::Error` only has the `Error::custom` method).

* [x] I've included my change in `CHANGELOG.md`
