### PR TITLE
Bump MSRV to 1.56.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.46.0, stable, nightly]
+        rust: [1.56.0, stable, nightly]
 
     steps:
       - uses: actions/checkout@v3
@@ -30,12 +30,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1
-        name: Downgrade indexmap to MSRV
-        if: ${{ matrix.rust }} == "1.46.0"
-        with:
-          command: update
-          args: -p indexmap --precise 1.8.2
       - run: cargo test
       - run: cargo test --features integer128
       - run: cargo test --features indexmap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `integer128` feature that guards `i128` and `u128` ([#304](https://github.com/ron-rs/ron/pull/304), [#351](https://github.com/ron-rs/ron/pull/351))
 - Fix issue [#265](https://github.com/ron-rs/ron/issues/265) with better missing comma error ([#353](https://github.com/ron-rs/ron/pull/353))
 - Fix issue [#301](https://github.com/ron-rs/ron/issues/301) with better error messages ([#354](https://github.com/ron-rs/ron/pull/354))
-- Bump MSRV to 1.46.0 ([#361](https://github.com/ron-rs/ron/pull/361))
 - Fix issue [#337](https://github.com/ron-rs/ron/issues/337) by removing `decimal_floats` PrettyConfig option and unconditional decimals in floats ([#363](https://github.com/ron-rs/ron/pull/363))
 - Fix issue [#203](https://github.com/ron-rs/ron/issues/203) with full de error positioning ([#356](https://github.com/ron-rs/ron/pull/356))
+- Bump MSRV to 1.56.0 ([#396](https://github.com/ron-rs/ron/pull/396))
 
 ## [0.7.1] - 2022-06-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ authors = [
 	"Dzmitry Malyshau <kvarkus@gmail.com>",
 	"Thomas Schaller <torkleyy@gmail.com>",
 ]
-edition = "2018"
+edition = "2021"
 description = "Rusty Object Notation"
 categories = ["encoding"]
 readme = "README.md"
 homepage = "https://github.com/ron-rs/ron"
 repository = "https://github.com/ron-rs/ron"
 documentation = "https://docs.rs/ron/"
-exclude = ["bors.toml", ".travis.yml"]
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/ron-rs/ron/actions/workflows/ci.yaml/badge.svg)](https://github.com/ron-rs/ron/actions/workflows/ci.yaml)
 [![codecov](https://img.shields.io/codecov/c/github/ron-rs/ron/codecov?token=x4Q5KA51Ul)](https://codecov.io/gh/ron-rs/ron)
 [![Crates.io](https://img.shields.io/crates/v/ron.svg)](https://crates.io/crates/ron)
-[![MSRV](https://img.shields.io/badge/MSRV-1.46.0-orange)](https://github.com/ron-rs/ron)
+[![MSRV](https://img.shields.io/badge/MSRV-1.56.0-orange)](https://github.com/ron-rs/ron)
 [![Docs](https://docs.rs/ron/badge.svg)](https://docs.rs/ron)
 [![Matrix](https://img.shields.io/matrix/ron-rs:matrix.org.svg)](https://matrix.to/#/#ron-rs:matrix.org)
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.46.0"
+msrv = "1.56.0"
 blacklisted-names = []


### PR DESCRIPTION
Bumps MSRV to 1.56.0, the version when the 2021 edition was introduced.

* [x] I've included my change in `CHANGELOG.md`
