### PR TITLE
Prepare v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.8.0] - 2022-08-17
 - Add `integer128` feature that guards `i128` and `u128` ([#304](https://github.com/ron-rs/ron/pull/304), [#351](https://github.com/ron-rs/ron/pull/351))
 - Fix issue [#265](https://github.com/ron-rs/ron/issues/265) with better missing comma error ([#353](https://github.com/ron-rs/ron/pull/353))
 - Fix issue [#301](https://github.com/ron-rs/ron/issues/301) with better error messages ([#354](https://github.com/ron-rs/ron/pull/354))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ron"
 # Memo: update version in src/lib.rs too (doc link)
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT/Apache-2.0"
 keywords = ["parser", "serde", "serialization"]
 authors = [

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Note the following advantages of RON over JSON:
 
 ```toml
 [dependencies]
-ron = "0.7"
+ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ Serializing / Deserializing is as simple as calling `to_string` / `from_str`.
 
 !*/
 
-#![doc(html_root_url = "https://docs.rs/ron/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/ron/0.8.0")]
 
 pub mod de;
 pub mod ser;


### PR DESCRIPTION
Update `CHANGELOG`, `README`, `Cargo.toml`, and `src/lib.rs` for the v0.8.0 release.

* [x] I've included my change in `CHANGELOG.md`
