### PR TITLE
Expected bytes error and import cleanup

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+
 use ron::de::from_str;
 use serde::Deserialize;
-use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 struct Config {

--- a/examples/decode_file.rs
+++ b/examples/decode_file.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use std::{collections::HashMap, fs::File};
+
 use ron::de::from_reader;
 use serde::Deserialize;
-use std::{collections::HashMap, fs::File};
 
 #[derive(Debug, Deserialize)]
 struct Config {

--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -1,6 +1,7 @@
+use std::{collections::HashMap, iter::FromIterator};
+
 use ron::ser::{to_string_pretty, PrettyConfig};
 use serde::Serialize;
-use std::{collections::HashMap, iter::FromIterator};
 
 #[derive(Serialize)]
 struct Config {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
 hard_tabs = false
 use_field_init_shorthand = true
 use_try_shorthand = true
-edition = "2018"
+edition = "2021"

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,10 +1,10 @@
 /// Deserialization module.
-pub use crate::error::{Error, Position, SpannedError};
-
-use serde::de::{self, DeserializeSeed, Deserializer as SerdeError, Visitor};
 use std::{borrow::Cow, io, str};
 
+use serde::de::{self, DeserializeSeed, Deserializer as SerdeError, Visitor};
+
 use self::{id::IdDeserializer, tag::TagDeserializer};
+pub use crate::error::{Error, Position, SpannedError};
 use crate::{
     error::{Result, SpannedResult},
     extensions::Extensions,

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -162,8 +162,9 @@ fn err<T>(kind: Error, line: usize, col: usize) -> SpannedResult<T> {
 
 #[test]
 fn test_err_wrong_value() {
-    use self::Error::*;
     use std::collections::HashMap;
+
+    use self::Error::*;
 
     assert_eq!(from_str::<f32>("'c'"), err(ExpectedFloat, 1, 1));
     assert_eq!(from_str::<String>("'c'"), err(ExpectedString, 1, 1));

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -5,8 +5,10 @@ use serde::{
     Deserialize, Deserializer,
 };
 
-use crate::error::SpannedResult;
-use crate::value::{Map, Number, Value};
+use crate::{
+    error::SpannedResult,
+    value::{Map, Number, Value},
+};
 
 impl std::str::FromStr for Value {
     type Err = crate::error::SpannedError;
@@ -181,8 +183,9 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     fn eval(s: &str) -> Value {
         s.parse().expect("Failed to parse")

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-use serde::{de, ser};
 use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Error};
+
+use serde::{de, ser};
 
 /// This type represents all possible errors that can occur when
 /// serializing or deserializing RON data.
@@ -276,15 +277,9 @@ impl de::Error for Error {
                     Float(n) => write!(f, "the floating point number `{}`", n),
                     Char(c) => write!(f, "the UTF-8 character `{}`", c),
                     Str(s) => write!(f, "the string {:?}", s),
-                    Bytes(b) => {
-                        f.write_str("the bytes b\"")?;
-
-                        for b in b {
-                            write!(f, "\\x{:02x}", b)?;
-                        }
-
-                        f.write_str("\"")
-                    }
+                    Bytes(b) => write!(f, "the bytes \"{}\"", {
+                        base64::display::Base64Display::with_config(b, base64::STANDARD)
+                    }),
                     Unit => write!(f, "a unit value"),
                     Option => write!(f, "an optional value"),
                     NewtypeStruct => write!(f, "a newtype struct"),

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,10 +4,12 @@ use std::io;
 
 use serde::{de, ser, Deserialize, Serialize};
 
-use crate::de::Deserializer;
-use crate::error::{Result, SpannedResult};
-use crate::extensions::Extensions;
-use crate::ser::{PrettyConfig, Serializer};
+use crate::{
+    de::Deserializer,
+    error::{Result, SpannedResult},
+    extensions::Extensions,
+    ser::{PrettyConfig, Serializer},
+};
 
 /// Roundtrip serde options.
 ///

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,5 +1,6 @@
-use serde::{ser, Deserialize, Serialize};
 use std::io;
+
+use serde::{ser, Deserialize, Serialize};
 
 use crate::{
     error::{Error, Result},

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,5 +1,6 @@
-use super::to_string;
 use serde::Serialize;
+
+use super::to_string;
 
 #[derive(Serialize)]
 struct EmptyStruct1;

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,8 +12,7 @@ use serde::{
     forward_to_deserialize_any, Deserialize, Serialize,
 };
 
-use crate::de::Error;
-use crate::error::Result;
+use crate::{de::Error, error::Result};
 
 /// A `Value` to `Value` map.
 ///
@@ -484,9 +483,11 @@ impl<'de> SeqAccess<'de> for Seq {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use serde::Deserialize;
     use std::{collections::BTreeMap, fmt::Debug};
+
+    use serde::Deserialize;
+
+    use super::*;
 
     fn assert_same<'de, T>(s: &'de str)
     where

--- a/tests/123_enum_representation.rs
+++ b/tests/123_enum_representation.rs
@@ -1,6 +1,7 @@
+use std::{cmp::PartialEq, fmt::Debug};
+
 use ron::{de::from_str, ser::to_string};
 use serde::{Deserialize, Serialize};
-use std::{cmp::PartialEq, fmt::Debug};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 enum Inner {

--- a/tests/147_empty_sets_serialisation.rs
+++ b/tests/147_empty_sets_serialisation.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct UnitStruct;

--- a/tests/250_variant_newtypes.rs
+++ b/tests/250_variant_newtypes.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use ron::{
-    de::from_str, error::Error, extensions::Extensions, ser::to_string_pretty, ser::PrettyConfig,
+    de::from_str,
+    error::Error,
+    extensions::Extensions,
+    ser::{to_string_pretty, PrettyConfig},
 };
 use serde::{Deserialize, Serialize};
 

--- a/tests/depth_limit.rs
+++ b/tests/depth_limit.rs
@@ -1,5 +1,6 @@
-use serde::Serialize;
 use std::collections::HashMap;
+
+use serde::Serialize;
 
 #[derive(Serialize)]
 struct Config {

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -1,6 +1,7 @@
+use std::{char::from_u32, fmt::Debug};
+
 use ron::{de::from_str, ser::to_string};
 use serde::{Deserialize, Serialize};
-use std::{char::from_u32, fmt::Debug};
 
 #[test]
 fn test_escape_basic() {

--- a/tests/extensions.rs
+++ b/tests/extensions.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct UnitStruct;

--- a/tests/numbers.rs
+++ b/tests/numbers.rs
@@ -1,5 +1,7 @@
-use ron::de::from_str;
-use ron::error::{Error, Position, SpannedError};
+use ron::{
+    de::from_str,
+    error::{Error, Position, SpannedError},
+};
 
 #[test]
 fn test_hex() {

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use ron::{extensions::Extensions, ser::PrettyConfig, Options};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct Newtype(f64);

--- a/tests/preserve_sequence.rs
+++ b/tests/preserve_sequence.rs
@@ -1,9 +1,10 @@
+use std::collections::BTreeMap;
+
 use ron::{
     de::from_str,
     ser::{to_string_pretty, PrettyConfig},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Config {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use ron::extensions::Extensions;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct UnitStruct;

--- a/tests/to_string_pretty.rs
+++ b/tests/to_string_pretty.rs
@@ -1,5 +1,7 @@
-use ron::ser::{to_string_pretty, PrettyConfig};
-use ron::to_string;
+use ron::{
+    ser::{to_string_pretty, PrettyConfig},
+    to_string,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,6 +1,7 @@
+use std::f64;
+
 use ron::value::{Map, Number, Value};
 use serde::Serialize;
-use std::f64;
 
 #[test]
 fn bool() {


### PR DESCRIPTION
This cleanup PR includes
- a small change to the error message for the unexpected bytes error to print the bytesrting with base64, since that's how it shows up in the ron
- reformatting of all import statements (using the unstable `imports_granularity = "Crate"` and `group_imports = "StdExternalCrate"` options)

~~* [ ] I've included my change in `CHANGELOG.md`~~
