### PR TITLE
Fixed raw struct name identifier parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix issue [#401](https://github.com/ron-rs/ron/issues/401) with correct raw struct name identifier parsing ([#402](https://github.com/ron-rs/ron/pull/402))
+
 ## [0.8.0] - 2022-08-17
 
 - Bump dependencies: `bitflags` to 1.3, `indexmap` to 1.9 ([#399](https://github.com/ron-rs/ron/pull/399))

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -138,3 +138,14 @@ enum_variant_unit = ident;
 enum_variant_tuple = ident, ws, tuple;
 enum_variant_named = ident, ws, "(", [named_field, { comma, named_field }, [comma]], ")";
 ```
+
+## Identifier
+
+```ebnf
+ident = ident_std | ident_raw;
+ident_std = ident_std_first, { ident_std_rest };
+ident_std_first = "A" | ... | "Z" | "a" | ... | "z" | "_";
+ident_std_rest = ident_std_first | digit;
+ident_raw = "r", "#", ident_raw_rest, { ident_raw_rest };
+ident_raw_rest = ident_std_rest | "." | "+" | "-";
+```

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,7 @@ pub enum Error {
         field: &'static str,
         outer: Option<String>,
     },
+    InvalidIdentifier(String),
 }
 
 impl fmt::Display for SpannedError {
@@ -227,6 +228,7 @@ impl fmt::Display for Error {
                     None => Ok(()),
                 }
             }
+            Error::InvalidIdentifier(ref invalid) => write!(f, "Invalid identifier {:?}", invalid),
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -77,7 +77,7 @@ pub const fn is_ident_other_char(c: u8) -> bool {
     ENCODINGS[c as usize] & IDENT_OTHER_CHAR != 0
 }
 
-const fn is_ident_raw_char(c: u8) -> bool {
+pub const fn is_ident_raw_char(c: u8) -> bool {
     ENCODINGS[c as usize] & IDENT_RAW_CHAR != 0
 }
 
@@ -450,27 +450,26 @@ impl<'a> Bytes<'a> {
 
     pub fn consume_struct_name(&mut self, ident: &'static str) -> Result<bool> {
         if self.check_ident("") {
-            Ok(false)
-        } else if ident.is_empty() {
-            Err(Error::ExpectedStructLike)
-        } else if self.check_ident(ident) {
-            let _ = self.advance(ident.len());
-
-            Ok(true)
-        } else {
-            // If the following is not even an identifier, then a missing
-            //  opening `(` seems more likely
-            let maybe_ident = self
-                .identifier()
-                .map_err(|_| Error::ExpectedNamedStructLike(ident))?;
-
-            let found = std::str::from_utf8(maybe_ident).map_err(Error::from)?;
-
-            Err(Error::ExpectedDifferentStructName {
-                expected: ident,
-                found: String::from(found),
-            })
+            return Ok(false);
         }
+
+        if ident.is_empty() {
+            return Err(Error::ExpectedStructLike);
+        }
+
+        let found_ident = match self.identifier() {
+            Ok(maybe_ident) => std::str::from_utf8(maybe_ident)?,
+            Err(_) => return Err(Error::ExpectedNamedStructLike(ident)),
+        };
+
+        if found_ident != ident {
+            return Err(Error::ExpectedDifferentStructName {
+                expected: ident,
+                found: String::from(found_ident),
+            });
+        }
+
+        Ok(true)
     }
 
     pub fn consume(&mut self, s: &str) -> bool {

--- a/tests/401_raw_identifier.rs
+++ b/tests/401_raw_identifier.rs
@@ -11,6 +11,7 @@ struct EmptyStruct;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(rename = "Hello+World")]
+#[serde(deny_unknown_fields)]
 struct RawStruct {
     #[serde(rename = "ab.cd-ef")]
     field: bool,
@@ -58,6 +59,81 @@ fn test_invalid_identifiers() {
             code: Error::ExpectedUnit,
             position: Position { line: 1, col: 1 },
         }
+    );
+
+    let de = ron::from_str::<EmptyStruct>("r#").unwrap_err();
+    assert_eq!(
+        format!("{}", de),
+        "1:1: Expected only opening `(`, no name, for un-nameable struct"
+    );
+
+    let de = ron::from_str::<RawStruct>("Hello+World").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::SuggestRawIdentifier(String::from("Hello+World")),
+            position: Position { line: 1, col: 1 },
+        }
+    );
+
+    let de = ron::from_str::<RawStruct>(
+        "r#Hello+World(
+        ab.cd-ef: true,
+    )",
+    )
+    .unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::SuggestRawIdentifier(String::from("ab.cd-ef")),
+            position: Position { line: 2, col: 9 },
+        }
+    );
+
+    let de = ron::from_str::<RawStruct>(
+        "r#Hello+World(
+        r#ab.cd+ef: true,
+    )",
+    )
+    .unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::NoSuchStructField {
+                expected: &["ab.cd-ef"],
+                found: String::from("ab.cd+ef"),
+                outer: Some(String::from("Hello+World")),
+            },
+            position: Position { line: 2, col: 19 },
+        }
+    );
+
+    let de = ron::from_str::<RawEnum>("Hello-World").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::SuggestRawIdentifier(String::from("Hello-World")),
+            position: Position { line: 1, col: 1 },
+        }
+    );
+
+    let de = ron::from_str::<RawEnum>("r#Hello+World").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::NoSuchEnumVariant {
+                expected: &["Hello-World"],
+                found: String::from("Hello+World"),
+                outer: Some(String::from("RawEnum")),
+            },
+            position: Position { line: 1, col: 14 },
+        }
+    );
+
+    let de = ron::from_str::<EmptyStruct>("r#+").unwrap_err();
+    assert_eq!(
+        format!("{}", de),
+        r#"1:4: Expected struct ""_[invalid identifier] but found `r#+`"#,
     );
 }
 

--- a/tests/401_raw_identifier.rs
+++ b/tests/401_raw_identifier.rs
@@ -67,6 +67,24 @@ fn test_invalid_identifiers() {
         "1:1: Expected only opening `(`, no name, for un-nameable struct"
     );
 
+    let de = ron::from_str::<RawStruct>("").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::ExpectedNamedStructLike("Hello+World"),
+            position: Position { line: 1, col: 1 },
+        },
+    );
+
+    let de = ron::from_str::<RawStruct>("r#").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::ExpectedNamedStructLike("Hello+World"),
+            position: Position { line: 1, col: 1 },
+        },
+    );
+
     let de = ron::from_str::<RawStruct>("Hello+World").unwrap_err();
     assert_eq!(
         de,

--- a/tests/401_raw_identifier.rs
+++ b/tests/401_raw_identifier.rs
@@ -1,0 +1,83 @@
+use ron::error::{Error, Position, SpannedError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename = "Hello World")]
+struct InvalidStruct;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename = "")]
+struct EmptyStruct;
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(rename = "Hello+World")]
+struct RawStruct {
+    #[serde(rename = "ab.cd-ef")]
+    field: bool,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+enum RawEnum {
+    #[serde(rename = "Hello-World")]
+    RawVariant,
+}
+
+#[test]
+fn test_invalid_identifiers() {
+    let ser = ron::ser::to_string_pretty(
+        &InvalidStruct,
+        ron::ser::PrettyConfig::default().struct_names(true),
+    );
+    assert_eq!(
+        ser,
+        Err(Error::InvalidIdentifier(String::from("Hello World")))
+    );
+
+    let ser = ron::ser::to_string_pretty(
+        &EmptyStruct,
+        ron::ser::PrettyConfig::default().struct_names(true),
+    );
+    assert_eq!(ser, Err(Error::InvalidIdentifier(String::from(""))));
+
+    let de = ron::from_str::<InvalidStruct>("Hello World").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::ExpectedDifferentStructName {
+                expected: "Hello World",
+                found: String::from("Hello"),
+            },
+            position: Position { line: 1, col: 6 },
+        }
+    );
+
+    let de = ron::from_str::<EmptyStruct>("").unwrap_err();
+    assert_eq!(
+        de,
+        SpannedError {
+            code: Error::ExpectedUnit,
+            position: Position { line: 1, col: 1 },
+        }
+    );
+}
+
+#[test]
+fn test_raw_identifier_roundtrip() {
+    let val = RawStruct { field: true };
+
+    let ser =
+        ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default().struct_names(true))
+            .unwrap();
+    assert_eq!(ser, "r#Hello+World(\n    r#ab.cd-ef: true,\n)");
+
+    let de: RawStruct = ron::from_str(&ser).unwrap();
+    assert_eq!(de, val);
+
+    let val = RawEnum::RawVariant;
+
+    let ser = ron::ser::to_string(&val).unwrap();
+    assert_eq!(ser, "r#Hello-World");
+
+    let de: RawEnum = ron::from_str(&ser).unwrap();
+    assert_eq!(de, val);
+}


### PR DESCRIPTION
Fixes #401

- adds documentation about valid identifiers to the grammar
- checks identifier validity upon serialisation
- fix struct name parsing to support raw identifiers

@torkleyy Deserialisation currently does NOT validate expected identifiers, so one could get an error saying `found "World" but expected "Hello World"` which has absolutely no user-side fix if you don't control the data structure you're deserialising into. I could specialise the error messages to add a note if an invalid identifier was expected, but that might clutter the code base.

* [x] I've included my change in `CHANGELOG.md`
