### PR TITLE
Fix #277 and #405 with `Value::Map` `IntoIter` and extraneous item check for `Value::Seq`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix issues [#277](https://github.com/ron-rs/ron/issues/277) and [#405](https://github.com/ron-rs/ron/issues/405) with `Value::Map` `IntoIter` and extraneous item check for `Value::Seq` ([#406](https://github.com/ron-rs/ron/pull/406))
+
 ## [0.8.0] - 2022-08-17
 
 - Bump dependencies: `bitflags` to 1.3, `indexmap` to 1.9 ([#399](https://github.com/ron-rs/ron/pull/399))

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,6 +1,9 @@
 use std::f64;
 
-use ron::value::{Map, Number, Value};
+use ron::{
+    error::Error,
+    value::{Map, Number, Value},
+};
 use serde::Serialize;
 
 #[test]
@@ -68,6 +71,34 @@ fn seq() {
         Value::Number(Number::new(2f64)),
     ];
     assert_eq!("[1, 2.0]".parse(), Ok(Value::Seq(seq)));
+
+    let err = Value::Seq(vec![Value::Number(Number::new(1))])
+        .into_rust::<[i32; 2]>()
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        Error::ExpectedDifferentLength {
+            expected: String::from("an array of length 2"),
+            found: 1,
+        }
+    );
+
+    let err = Value::Seq(vec![
+        Value::Number(Number::new(1)),
+        Value::Number(Number::new(2)),
+        Value::Number(Number::new(3)),
+    ])
+    .into_rust::<[i32; 2]>()
+    .unwrap_err();
+
+    assert_eq!(
+        err,
+        Error::ExpectedDifferentLength {
+            expected: String::from("a sequence of length 2"),
+            found: 3,
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #277
Fixes #405

* [x] I've included my change in `CHANGELOG.md`
