### PR TITLE
Implemented ron::value::RawValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issues [#277](https://github.com/ron-rs/ron/issues/277) and [#405](https://github.com/ron-rs/ron/issues/405) with `Value::Map` `IntoIter` and extraneous item check for `Value::Seq` ([#406](https://github.com/ron-rs/ron/pull/406))
 - Fix issue [#401](https://github.com/ron-rs/ron/issues/401) with correct raw struct name identifier parsing ([#402](https://github.com/ron-rs/ron/pull/402))
+- Add `ron::value::RawValue` helper type which can (de)serialize any valid RON ([#407](https://github.com/ron-rs/ron/pull/407))
 
 ## [0.8.0] - 2022-08-17
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,7 @@ pub enum Error {
     },
     InvalidIdentifier(String),
     SuggestRawIdentifier(String),
+    ExpectedRawValue,
 }
 
 impl fmt::Display for SpannedError {
@@ -248,6 +249,7 @@ impl fmt::Display for Error {
                 "Found invalid std identifier `{}`, try the raw identifier `r#{}` instead",
                 identifier, identifier
             ),
+            Error::ExpectedRawValue => f.write_str("Expected a `ron::value::RawValue`"),
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -355,7 +355,7 @@ impl<'a> Bytes<'a> {
         }
     }
 
-    pub fn bytes(&self) -> &[u8] {
+    pub fn bytes(&self) -> &'a [u8] {
         self.bytes
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char, LargeSInt, LargeUInt},
 };
 
+mod raw;
 #[cfg(test)]
 mod tests;
 mod value;
@@ -533,6 +534,10 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     where
         T: ?Sized + Serialize,
     {
+        if name == crate::value::raw::RAW_VALUE_TOKEN {
+            return value.serialize(raw::RawValueSerializer::new(self));
+        }
+
         if self.extensions().contains(Extensions::UNWRAP_NEWTYPES) || self.newtype_variant {
             self.newtype_variant = false;
 

--- a/src/ser/raw.rs
+++ b/src/ser/raw.rs
@@ -1,0 +1,172 @@
+use std::io;
+
+use serde::{ser, Serialize};
+
+use super::{Error, Result, Serializer};
+
+pub struct RawValueSerializer<'a, W: io::Write> {
+    ser: &'a mut Serializer<W>,
+}
+
+impl<'a, W: io::Write> RawValueSerializer<'a, W> {
+    pub fn new(ser: &'a mut Serializer<W>) -> Self {
+        Self { ser }
+    }
+}
+
+impl<'a, W: io::Write> ser::Serializer for RawValueSerializer<'a, W> {
+    type Error = Error;
+    type Ok = ();
+    type SerializeMap = ser::Impossible<(), Error>;
+    type SerializeSeq = ser::Impossible<(), Error>;
+    type SerializeStruct = ser::Impossible<(), Error>;
+    type SerializeStructVariant = ser::Impossible<(), Error>;
+    type SerializeTuple = ser::Impossible<(), Error>;
+    type SerializeTupleStruct = ser::Impossible<(), Error>;
+    type SerializeTupleVariant = ser::Impossible<(), Error>;
+
+    fn serialize_bool(self, _: bool) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_i8(self, _: i8) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_i16(self, _: i16) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_i32(self, _: i32) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_i64(self, _: i64) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    #[cfg(feature = "integer128")]
+    fn serialize_i128(self, _: i128) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_u8(self, _: u8) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_u16(self, _: u16) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_u32(self, _: u32) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_u64(self, _: u64) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    #[cfg(feature = "integer128")]
+    fn serialize_u128(self, _: u128) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_f32(self, _: f32) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_f64(self, _: f64) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_char(self, _: char) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_str(self, ron: &str) -> Result<()> {
+        self.ser.output.write_all(ron.as_bytes())?;
+        Ok(())
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_none(self) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(self, _: &T) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_unit(self) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(self, _: &'static str, _: &T) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &T,
+    ) -> Result<()> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct> {
+        Err(Error::ExpectedRawValue)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(Error::ExpectedRawValue)
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -14,6 +14,10 @@ use serde::{
 
 use crate::{de::Error, error::Result};
 
+pub(crate) mod raw;
+
+pub use raw::RawValue;
+
 /// A `Value` to `Value` map.
 ///
 /// This structure either uses a [BTreeMap](std::collections::BTreeMap) or the

--- a/src/value/raw.rs
+++ b/src/value/raw.rs
@@ -1,0 +1,182 @@
+// Inspired by David Tolnay's serde-rs
+// https://github.com/serde-rs/json/blob/master/src/raw.rs
+// Licensed under either of Apache License, Version 2.0 or MIT license at your option.
+
+use std::fmt;
+
+use serde::{de, ser, Deserialize, Serialize};
+
+use crate::{
+    error::{Error, SpannedResult},
+    options::Options,
+};
+
+pub(crate) const RAW_VALUE_TOKEN: &str = "$ron::private::RawValue";
+
+#[repr(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RawValue {
+    ron: str,
+}
+
+impl RawValue {
+    fn from_borrowed(ron: &str) -> &Self {
+        unsafe { std::mem::transmute::<&str, &RawValue>(ron) }
+    }
+
+    fn from_owned(ron: Box<str>) -> Box<Self> {
+        unsafe { std::mem::transmute::<Box<str>, Box<RawValue>>(ron) }
+    }
+
+    fn into_owned(raw_value: Box<Self>) -> Box<str> {
+        unsafe { std::mem::transmute::<Box<RawValue>, Box<str>>(raw_value) }
+    }
+}
+
+impl Clone for Box<RawValue> {
+    fn clone(&self) -> Self {
+        (**self).to_owned()
+    }
+}
+
+impl ToOwned for RawValue {
+    type Owned = Box<RawValue>;
+
+    fn to_owned(&self) -> Self::Owned {
+        RawValue::from_owned(self.ron.to_owned().into_boxed_str())
+    }
+}
+
+impl fmt::Debug for RawValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("RawValue")
+            .field(&format_args!("{}", &self.ron))
+            .finish()
+    }
+}
+
+impl fmt::Display for RawValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.ron)
+    }
+}
+
+impl RawValue {
+    /// Get the inner raw RON string, which is guaranteed to contain valid RON.
+    pub fn get_ron(&self) -> &str {
+        &self.ron
+    }
+
+    /// Helper function to validate a RON string and turn it into a `RawValue`.
+    pub fn from_ron(ron: &str) -> SpannedResult<&Self> {
+        Options::default()
+            .from_str::<&Self>(ron)
+            .map(|_| Self::from_borrowed(ron))
+    }
+
+    /// Helper function to deserialize the inner RON string into `T`.
+    pub fn into_rust<'de, T: Deserialize<'de>>(&'de self) -> SpannedResult<T> {
+        Options::default().from_str(&self.ron)
+    }
+
+    /// Helper function to serialize `value` into a RON string.
+    pub fn from_rust<T: Serialize>(value: &T) -> Result<Box<Self>, Error> {
+        let ron = Options::default().to_string(value)?;
+
+        Ok(RawValue::from_owned(ron.into_boxed_str()))
+    }
+}
+
+impl From<Box<RawValue>> for Box<str> {
+    fn from(raw_value: Box<RawValue>) -> Self {
+        RawValue::into_owned(raw_value)
+    }
+}
+
+impl From<Box<RawValue>> for String {
+    fn from(raw_value: Box<RawValue>) -> Self {
+        RawValue::into_owned(raw_value).into_string()
+    }
+}
+
+impl Serialize for RawValue {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_newtype_struct(RAW_VALUE_TOKEN, &self.ron)
+    }
+}
+
+impl<'de: 'a, 'a> Deserialize<'de> for &'a RawValue {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ReferenceVisitor;
+
+        impl<'de> de::Visitor<'de> for ReferenceVisitor {
+            type Value = &'de RawValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "any valid RON value")
+            }
+
+            fn visit_borrowed_str<E: de::Error>(self, ron: &'de str) -> Result<Self::Value, E> {
+                match Options::default().from_str::<serde::de::IgnoredAny>(ron) {
+                    Ok(_) => Ok(RawValue::from_borrowed(ron)),
+                    Err(err) => Err(de::Error::custom(format!(
+                        "invalid RON value at {}: {}",
+                        err.position, err.code
+                    ))),
+                }
+            }
+
+            fn visit_newtype_struct<D: de::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<Self::Value, D::Error> {
+                deserializer.deserialize_str(self)
+            }
+        }
+
+        deserializer.deserialize_newtype_struct(RAW_VALUE_TOKEN, ReferenceVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Box<RawValue> {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct BoxedVisitor;
+
+        impl<'de> de::Visitor<'de> for BoxedVisitor {
+            type Value = Box<RawValue>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "any valid RON value")
+            }
+
+            fn visit_str<E: de::Error>(self, ron: &str) -> Result<Self::Value, E> {
+                match Options::default().from_str::<serde::de::IgnoredAny>(ron) {
+                    Ok(_) => Ok(RawValue::from_owned(ron.to_owned().into_boxed_str())),
+                    Err(err) => Err(de::Error::custom(format!(
+                        "invalid RON value at {}: {}",
+                        err.position, err.code
+                    ))),
+                }
+            }
+
+            fn visit_string<E: de::Error>(self, ron: String) -> Result<Self::Value, E> {
+                match Options::default().from_str::<serde::de::IgnoredAny>(&ron) {
+                    Ok(_) => Ok(RawValue::from_owned(ron.into_boxed_str())),
+                    Err(err) => Err(de::Error::custom(format!(
+                        "invalid RON value at {}: {}",
+                        err.position, err.code
+                    ))),
+                }
+            }
+
+            fn visit_newtype_struct<D: de::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<Self::Value, D::Error> {
+                deserializer.deserialize_str(self)
+            }
+        }
+
+        deserializer.deserialize_newtype_struct(RAW_VALUE_TOKEN, BoxedVisitor)
+    }
+}

--- a/src/value/raw.rs
+++ b/src/value/raw.rs
@@ -77,6 +77,14 @@ impl RawValue {
             .map(|_| Self::from_borrowed_str(ron))
     }
 
+    /// Helper function to validate a RON string and turn it into a `RawValue`.
+    pub fn from_boxed_ron(ron: Box<str>) -> SpannedResult<Box<Self>> {
+        match Options::default().from_str::<&Self>(&*ron) {
+            Ok(_) => Ok(Self::from_boxed_str(ron)),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Helper function to deserialize the inner RON string into `T`.
     pub fn into_rust<'de, T: Deserialize<'de>>(&'de self) -> SpannedResult<T> {
         Options::default().from_str(&self.ron)
@@ -93,12 +101,6 @@ impl RawValue {
 impl From<Box<RawValue>> for Box<str> {
     fn from(raw_value: Box<RawValue>) -> Self {
         RawValue::into_boxed_str(raw_value)
-    }
-}
-
-impl From<Box<RawValue>> for String {
-    fn from(raw_value: Box<RawValue>) -> Self {
-        RawValue::into_boxed_str(raw_value).into_string()
     }
 }
 

--- a/tests/407_raw_value.rs
+++ b/tests/407_raw_value.rs
@@ -74,6 +74,20 @@ fn test_raw_value_from_ron() {
             position: Position { line: 1, col: 3 }
         }
     );
+
+    let raw =
+        RawValue::from_boxed_ron(String::from("/* hi */ (None, 4.2) /* bye */").into_boxed_str())
+            .unwrap();
+    assert_eq!(raw.get_ron(), "/* hi */ (None, 4.2) /* bye */");
+
+    let err = RawValue::from_boxed_ron(String::from("(").into_boxed_str()).unwrap_err();
+    assert_eq!(
+        err,
+        SpannedError {
+            code: Error::Eof,
+            position: Position { line: 1, col: 2 },
+        }
+    );
 }
 
 #[test]

--- a/tests/407_raw_value.rs
+++ b/tests/407_raw_value.rs
@@ -133,4 +133,50 @@ fn test_raw_value_serde_json() {
         err.to_string(),
         "invalid RON value at 1:13: Unexpected byte ')' at line 1 column 39"
     );
+
+    let err = serde_json::from_str::<WithRawValue>("{\"a\":true,\"b\":42}").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "invalid type: integer `42`, expected any valid RON-value-string at line 1 column 16"
+    );
+
+    let err = serde_json::from_str::<&RawValue>("\"/* hi */ (a:) /* bye */\"").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "invalid RON value at 1:13: Unexpected byte ')' at line 1 column 25"
+    );
+
+    let err = serde_json::from_str::<&RawValue>("42").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "invalid type: integer `42`, expected any valid borrowed RON-value-string at line 1 column 2"
+    );
+}
+
+#[test]
+fn test_raw_value_clone_into() {
+    let raw: Box<RawValue> = from_str("(None, 4.2)").unwrap();
+    let raw2 = raw.clone();
+    assert_eq!(raw, raw2);
+
+    let boxed_str: Box<str> = raw.into();
+    assert_eq!(&*boxed_str, "(None, 4.2)");
+
+    let string: String = raw2.into();
+    assert_eq!(string, "(None, 4.2)");
+}
+
+#[test]
+fn test_raw_value_debug_display() {
+    let raw = RawValue::from_ron("/* hi */ (None, 4.2) /* bye */").unwrap();
+
+    assert_eq!(format!("{}", raw), "/* hi */ (None, 4.2) /* bye */");
+    assert_eq!(
+        format!("{:#?}", raw),
+        "\
+RawValue(
+    /* hi */ (None, 4.2) /* bye */,
+)\
+    "
+    );
 }


### PR DESCRIPTION
Adds the `ron::value::RawValue` type, inspired by [`serde-rs`](https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html), which holds a valid RON fragment string and can be (de)serialised inside any container.

* [x] I've included my change in `CHANGELOG.md`
