### PR TITLE
Fix trailing comma parsing in tuples and Some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issues [#277](https://github.com/ron-rs/ron/issues/277) and [#405](https://github.com/ron-rs/ron/issues/405) with `Value::Map` `IntoIter` and extraneous item check for `Value::Seq` ([#406](https://github.com/ron-rs/ron/pull/406))
 - Fix issue [#401](https://github.com/ron-rs/ron/issues/401) with correct raw struct name identifier parsing ([#402](https://github.com/ron-rs/ron/pull/402))
 - Add `ron::value::RawValue` helper type which can (de)serialize any valid RON ([#407](https://github.com/ron-rs/ron/pull/407))
+- Fix issue [#410](https://github.com/ron-rs/ron/issues/410) trailing comma parsing in tuples and `Some` ([#412](https://github.com/ron-rs/ron/pull/412))
 
 ## [0.8.0] - 2022-08-17
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -161,7 +161,7 @@ impl<'de> Deserializer<'de> {
                     )
                 })?;
 
-            self.bytes.comma()?;
+            self.bytes.skip_ws()?;
 
             if old_newtype_variant || self.bytes.consume(")") {
                 Ok(value)
@@ -402,7 +402,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
             let v = visitor.visit_some(&mut *self)?;
 
-            self.bytes.skip_ws()?;
+            self.bytes.comma()?;
 
             if self.bytes.consume(")") {
                 Ok(v)
@@ -497,7 +497,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         if self.bytes.consume("[") {
             let value = visitor.visit_seq(CommaSeparated::new(b']', self))?;
-            self.bytes.comma()?;
+            self.bytes.skip_ws()?;
 
             if self.bytes.consume("]") {
                 Ok(value)
@@ -518,7 +518,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             self.newtype_variant = false;
 
             let value = visitor.visit_seq(CommaSeparated::new(b')', self))?;
-            self.bytes.comma()?;
+            self.bytes.skip_ws()?;
 
             if old_newtype_variant || self.bytes.consume(")") {
                 Ok(value)
@@ -557,7 +557,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         if self.bytes.consume("{") {
             let value = visitor.visit_map(CommaSeparated::new(b'}', self))?;
-            self.bytes.comma()?;
+            self.bytes.skip_ws()?;
 
             if self.bytes.consume("}") {
                 Ok(value)

--- a/tests/410_trailing_comma.rs
+++ b/tests/410_trailing_comma.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use ron::from_str;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Newtype(i32);
+
+#[derive(Deserialize)]
+struct Tuple(i32, i32);
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct Struct {
+    a: i32,
+    b: i32,
+}
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+enum Enum {
+    Newtype(i32),
+    Tuple(i32, i32),
+    Struct { a: i32, b: i32 },
+}
+
+#[test]
+fn test_trailing_comma_some() {
+    assert!(from_str::<Option<i32>>("Some(1)").is_ok());
+    assert!(from_str::<Option<i32>>("Some(1,)").is_ok());
+    assert!(from_str::<Option<i32>>("Some(1,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_tuple() {
+    assert!(from_str::<(i32, i32)>("(1,2)").is_ok());
+    assert!(from_str::<(i32, i32)>("(1,2,)").is_ok());
+    assert!(from_str::<(i32, i32)>("(1,2,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_list() {
+    assert!(from_str::<Vec<i32>>("[1,2]").is_ok());
+    assert!(from_str::<Vec<i32>>("[1,2,]").is_ok());
+    assert!(from_str::<Vec<i32>>("[1,2,,]").is_err());
+}
+
+#[test]
+fn test_trailing_comma_map() {
+    assert!(from_str::<HashMap<i32, bool>>("{1:false,2:true}").is_ok());
+    assert!(from_str::<HashMap<i32, bool>>("{1:false,2:true,}").is_ok());
+    assert!(from_str::<HashMap<i32, bool>>("{1:false,2:true,,}").is_err());
+}
+
+#[test]
+fn test_trailing_comma_newtype_struct() {
+    assert!(from_str::<Newtype>("(1)").is_ok());
+    assert!(from_str::<Newtype>("(1,)").is_ok());
+    assert!(from_str::<Newtype>("(1,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_tuple_struct() {
+    assert!(from_str::<Tuple>("(1,2)").is_ok());
+    assert!(from_str::<Tuple>("(1,2,)").is_ok());
+    assert!(from_str::<Tuple>("(1,2,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_struct() {
+    assert!(from_str::<Struct>("(a:1,b:2)").is_ok());
+    assert!(from_str::<Struct>("(a:1,b:2,)").is_ok());
+    assert!(from_str::<Struct>("(a:1,b:2,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_enum_newtype_variant() {
+    assert!(from_str::<Enum>("Newtype(1)").is_ok());
+    assert!(from_str::<Enum>("Newtype(1,)").is_ok());
+    assert!(from_str::<Enum>("Newtype(1,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_enum_tuple_variant() {
+    assert!(from_str::<Enum>("Tuple(1,2)").is_ok());
+    assert!(from_str::<Enum>("Tuple(1,2,)").is_ok());
+    assert!(from_str::<Enum>("Tuple(1,2,,)").is_err());
+}
+
+#[test]
+fn test_trailing_comma_enum_struct_variant() {
+    assert!(from_str::<Enum>("Struct(a:1,b:2)").is_ok());
+    assert!(from_str::<Enum>("Struct(a:1,b:2,)").is_ok());
+    assert!(from_str::<Enum>("Struct(a:1,b:2,,)").is_err());
+}


### PR DESCRIPTION
Fixes #410 trailing commas in all `Some`, tuples, structs, lists, maps, and enums.

- after using `CommaSeparated` we only need to skip whitespace, not an extra comma
- after newtype structs or variants we need to explicitly allow trailing commas

* [x] I've included my change in `CHANGELOG.md`
