### PR TITLE
[v0.9] Breaking: Treat Some like any newtype variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ron::value::RawValue` helper type which can (de)serialize any valid RON ([#407](https://github.com/ron-rs/ron/pull/407))
 - Fix issue [#410](https://github.com/ron-rs/ron/issues/410) trailing comma parsing in tuples and `Some` ([#412](https://github.com/ron-rs/ron/pull/412))
 - Error instead of panic when deserializing non-identifiers as field names ([#415](https://github.com/ron-rs/ron/pull/415))
+- Breaking: Treat `Some` like a newtype variant with `unwrap_variant_newtypes` ([#413](https://github.com/ron-rs/ron/pull/413))
 
 ## [0.8.0] - 2022-08-17
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -400,7 +400,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         } {
             self.bytes.skip_ws()?;
 
+            self.newtype_variant = self
+                .bytes
+                .exts
+                .contains(Extensions::UNWRAP_VARIANT_NEWTYPES);
+
             let v = visitor.visit_some(&mut *self)?;
+
+            self.newtype_variant = false;
 
             self.bytes.comma()?;
 

--- a/tests/250_variant_newtypes.rs
+++ b/tests/250_variant_newtypes.rs
@@ -287,6 +287,30 @@ fn test_deserialise_tuple_newtypes() {
 }
 
 #[test]
+fn test_newtype_some() {
+    assert_eq!(
+        from_str::<Option<Struct>>(r#"Some((a: 4, b: false))"#).unwrap(),
+        Some(Struct { a: 4, b: false }),
+    );
+
+    assert_eq!(
+        from_str::<Option<Struct>>(r#"Some(a: 4, b: false)"#)
+            .unwrap_err()
+            .code,
+        Error::ExpectedDifferentStructName {
+            expected: "Struct",
+            found: String::from("a"),
+        },
+    );
+
+    assert_eq!(
+        from_str::<Option<Struct>>(r#"#![enable(unwrap_variant_newtypes)] Some(a: 4, b: false)"#)
+            .unwrap(),
+        Some(Struct { a: 4, b: false }),
+    );
+}
+
+#[test]
 fn test_serialise_non_newtypes() {
     assert_eq_serialize_roundtrip(TestEnum::Unit, Extensions::UNWRAP_VARIANT_NEWTYPES);
 


### PR DESCRIPTION
How should `Some` be treated in the presence of the `unwrap_variant_newtypes` extension? With that extension, `NewtypeVariant(Some(a: 42, b: 24))` already worked, but `Some(a: 42, b: 24)` did not. In my opinion `Some` is just a newtype variant and should parse consistently here. @torkleyy what are your thoughts?

* [x] I've included my change in `CHANGELOG.md`
