### PR TITLE
Fix #423 deserialising an identifier into a borrowed str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue [#410](https://github.com/ron-rs/ron/issues/410) trailing comma parsing in tuples and `Some` ([#412](https://github.com/ron-rs/ron/pull/412))
 - Error instead of panic when deserializing non-identifiers as field names ([#415](https://github.com/ron-rs/ron/pull/415))
 - Breaking: Fix issue [#307](https://github.com/ron-rs/ron/issues/307) stack overflow with explicit recursion limits in serialising and deserialising ([#420](https://github.com/ron-rs/ron/pull/420))
+- Fix issue [#423](https://github.com/ron-rs/ron/issues/423) deserialising an identifier into a borrowed str ([#424](https://github.com/ron-rs/ron/pull/424))
 
 ## [0.8.0] - 2022-08-17
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -651,7 +651,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         self.last_identifier = Some(identifier);
 
-        visitor.visit_str(identifier)
+        visitor.visit_borrowed_str(identifier)
     }
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>

--- a/tests/423_de_borrowed_identifier.rs
+++ b/tests/423_de_borrowed_identifier.rs
@@ -1,0 +1,43 @@
+use std::any::Any;
+
+use serde::{
+    de::{MapAccess, Visitor},
+    Deserializer,
+};
+
+#[test]
+fn manually_deserialize_dyn() {
+    let ron = r#"SerializeDyn(
+        type: "engine_utils::types::registry::tests::Player",
+    )"#;
+
+    let mut de = ron::Deserializer::from_bytes(ron.as_bytes()).unwrap();
+
+    let result = de
+        .deserialize_struct("SerializeDyn", &["type"], SerializeDynVisitor)
+        .unwrap();
+
+    assert_eq!(
+        *result.downcast::<Option<(String, String)>>().unwrap(),
+        Some((
+            String::from("type"),
+            String::from("engine_utils::types::registry::tests::Player")
+        ))
+    );
+}
+
+struct SerializeDynVisitor;
+
+impl<'de> Visitor<'de> for SerializeDynVisitor {
+    type Value = Box<dyn Any>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "a serialize dyn struct")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let entry = map.next_entry::<&str, String>()?;
+
+        Ok(Box::new(entry.map(|(k, v)| (String::from(k), v))))
+    }
+}


### PR DESCRIPTION
Fixes #423 by deserialising an identifier using `visit_borrowed_str`. This was probably never caught before since serge-derived code uses the less strict `visit_str`, but deserialising into a `&str` requires the borrowing.

* [x] I've included my change in `CHANGELOG.md`
