### PR TITLE
Add `escape_strings` option to `PrettyConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error instead of panic when deserializing non-identifiers as field names ([#415](https://github.com/ron-rs/ron/pull/415))
 - Breaking: Fix issue [#307](https://github.com/ron-rs/ron/issues/307) stack overflow with explicit recursion limits in serialising and deserialising ([#420](https://github.com/ron-rs/ron/pull/420))
 - Fix issue [#423](https://github.com/ron-rs/ron/issues/423) deserialising an identifier into a borrowed str ([#424](https://github.com/ron-rs/ron/pull/424))
+- Add `escape_strings` option to `PrettyConfig` to allow serialising with or without escaping ([#426](https://github.com/ron-rs/ron/pull/426))
 
 ## [0.8.0] - 2022-08-17
 

--- a/tests/425_escape_strings.rs
+++ b/tests/425_escape_strings.rs
@@ -1,0 +1,60 @@
+use ron::{
+    de::from_str,
+    ser::{to_string, to_string_pretty, PrettyConfig},
+};
+
+fn test_string_roundtrip(s: &str, config: Option<PrettyConfig>) -> String {
+    let ser = match config {
+        Some(config) => to_string_pretty(s, config),
+        None => to_string(s),
+    }
+    .unwrap();
+
+    let de: String = from_str(&ser).unwrap();
+
+    assert_eq!(s, de);
+
+    ser
+}
+
+#[test]
+fn test_escaped_string() {
+    let config = Some(PrettyConfig::default());
+
+    assert_eq!(test_string_roundtrip("a\nb", None), r#""a\nb""#);
+    assert_eq!(test_string_roundtrip("a\nb", config.clone()), r#""a\nb""#);
+
+    assert_eq!(test_string_roundtrip("", None), "\"\"");
+    assert_eq!(test_string_roundtrip("", config.clone()), "\"\"");
+
+    assert_eq!(test_string_roundtrip("\"", None), r#""\"""#);
+    assert_eq!(test_string_roundtrip("\"", config.clone()), r#""\"""#);
+
+    assert_eq!(test_string_roundtrip("#", None), "\"#\"");
+    assert_eq!(test_string_roundtrip("#", config.clone()), "\"#\"");
+
+    assert_eq!(test_string_roundtrip("\"#", None), r##""\"#""##);
+    assert_eq!(test_string_roundtrip("\"#", config.clone()), r##""\"#""##);
+
+    assert_eq!(test_string_roundtrip("#\"#", None), r##""#\"#""##);
+    assert_eq!(test_string_roundtrip("#\"#", config.clone()), r##""#\"#""##);
+
+    assert_eq!(test_string_roundtrip("#\"##", None), r###""#\"##""###);
+    assert_eq!(test_string_roundtrip("#\"##", config), r###""#\"##""###);
+}
+
+#[test]
+fn test_unescaped_string() {
+    let config = Some(PrettyConfig::default().escape_strings(false));
+
+    assert_eq!(test_string_roundtrip("a\nb", config.clone()), "\"a\nb\"");
+    assert_eq!(test_string_roundtrip("", config.clone()), "\"\"");
+    assert_eq!(test_string_roundtrip("\"", config.clone()), "r#\"\"\"#");
+    assert_eq!(test_string_roundtrip("#", config.clone()), "\"#\"");
+    assert_eq!(test_string_roundtrip("\"#", config.clone()), "r##\"\"#\"##");
+    assert_eq!(
+        test_string_roundtrip("#\"#", config.clone()),
+        "r##\"#\"#\"##"
+    );
+    assert_eq!(test_string_roundtrip("#\"##", config), "r###\"#\"##\"###");
+}


### PR DESCRIPTION
This PR adds an `escape_strings` option to `PrettyConfig` that is enabled by default. When enabled, strings are serialised using escapes. When disabled, strings that contain no `"` are serialised literally. If the string does contain a `"`, a raw string literal with the minimum number of required leading `#` is emitted.

This feature was suggested in #425, i.e. this PR fixes #425.

* [ ] I've included my change in `CHANGELOG.md`