### PR TITLE
Bump MSRV to 1.57.0 and base64 to 0.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.56.0, stable, nightly]
+        rust: [1.57.0, stable, nightly]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: Fix issue [#307](https://github.com/ron-rs/ron/issues/307) stack overflow with explicit recursion limits in serialising and deserialising ([#420](https://github.com/ron-rs/ron/pull/420))
 - Fix issue [#423](https://github.com/ron-rs/ron/issues/423) deserialising an identifier into a borrowed str ([#424](https://github.com/ron-rs/ron/pull/424))
 - Add `escape_strings` option to `PrettyConfig` to allow serialising with or without escaping ([#426](https://github.com/ron-rs/ron/pull/426))
+- Bump MSRV to 1.57.0 and bump dependency: `base64` to 0.20 ([#431](https://github.com/ron-rs/ron/pull/431))
 
 ## [0.8.0] - 2022-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,21 @@ readme = "README.md"
 homepage = "https://github.com/ron-rs/ron"
 repository = "https://github.com/ron-rs/ron"
 documentation = "https://docs.rs/ron/"
-rust-version = "1.56.0"
+rust-version = "1.57.0"
 
 [features]
 default = []
 integer128 = []
 
 [dependencies]
-base64 = "0.13"
-bitflags = "1.3.2"
-indexmap = { version = "1.9.1", features = ["serde-1"], optional = true }
+base64 = "0.20"
+bitflags = "1.3"
+indexmap = { version = "1.9", features = ["serde-1"], optional = true }
+# serde supports i128/u128 from 1.0.60 onwards
 serde = { version = "1.0.60", features = ["serde_derive"] }
 
 [dev-dependencies]
 serde_bytes = "0.11"
-serde_json = "1"
+serde_json = "1.0"
 bitflags-serial = { git = "https://github.com/kvark/bitflags-serial" }
 option_set = "0.1"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/ron-rs/ron/actions/workflows/ci.yaml/badge.svg)](https://github.com/ron-rs/ron/actions/workflows/ci.yaml)
 [![codecov](https://img.shields.io/codecov/c/github/ron-rs/ron/codecov?token=x4Q5KA51Ul)](https://codecov.io/gh/ron-rs/ron)
 [![Crates.io](https://img.shields.io/crates/v/ron.svg)](https://crates.io/crates/ron)
-[![MSRV](https://img.shields.io/badge/MSRV-1.56.0-orange)](https://github.com/ron-rs/ron)
+[![MSRV](https://img.shields.io/badge/MSRV-1.57.0-orange)](https://github.com/ron-rs/ron)
 [![Docs](https://docs.rs/ron/badge.svg)](https://docs.rs/ron)
 [![Matrix](https://img.shields.io/matrix/ron-rs:matrix.org.svg)](https://matrix.to/#/#ron-rs:matrix.org)
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.56.0"
+msrv = "1.57.0"
 blacklisted-names = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -303,7 +303,7 @@ impl de::Error for Error {
                     Char(c) => write!(f, "the UTF-8 character `{}`", c),
                     Str(s) => write!(f, "the string {:?}", s),
                     Bytes(b) => write!(f, "the bytes \"{}\"", {
-                        base64::display::Base64Display::with_config(b, base64::STANDARD)
+                        base64::display::Base64Display::from(b, &base64::engine::DEFAULT_ENGINE)
                     }),
                     Unit => write!(f, "a unit value"),
                     Option => write!(f, "an optional value"),


### PR DESCRIPTION
Supersedes #430

If we want to upgrade to `base64` 0.20, we need to bump our MSRV to 1.57 as well.

* [x] I've included my change in `CHANGELOG.md`
