### PR TITLE
Bump base64 to v0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue [#423](https://github.com/ron-rs/ron/issues/423) deserialising an identifier into a borrowed str ([#424](https://github.com/ron-rs/ron/pull/424))
 - Add `escape_strings` option to `PrettyConfig` to allow serialising with or without escaping ([#426](https://github.com/ron-rs/ron/pull/426))
 - Bump MSRV to 1.57.0 and bump dependency: `base64` to 0.20 ([#431](https://github.com/ron-rs/ron/pull/431))
+- Bump dependency `base64` to 0.21 ([#433](https://github.com/ron-rs/ron/pull/433))
 
 ## [0.8.0] - 2022-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 integer128 = []
 
 [dependencies]
-base64 = "0.20"
+base64 = "0.21"
 bitflags = "1.3"
 indexmap = { version = "1.9", features = ["serde-1"], optional = true }
 # serde supports i128/u128 from 1.0.60 onwards

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,7 @@
 /// Deserialization module.
 use std::{borrow::Cow, io, str};
 
+use base64::Engine;
 use serde::de::{self, DeserializeSeed, Deserializer as SerdeError, Visitor};
 
 use self::{id::IdDeserializer, tag::TagDeserializer};
@@ -9,7 +10,7 @@ use crate::{
     error::{Result, SpannedResult},
     extensions::Extensions,
     options::Options,
-    parse::{AnyNum, Bytes, ParsedStr},
+    parse::{AnyNum, Bytes, ParsedStr, BASE64_ENGINE},
 };
 
 mod id;
@@ -403,7 +404,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 ParsedStr::Allocated(ref s) => s.as_str(),
                 ParsedStr::Slice(s) => s,
             };
-            base64::decode(base64_str)
+            BASE64_ENGINE.decode(base64_str)
         };
 
         match res {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Err
 
 use serde::{de, ser};
 
-use crate::parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char};
+use crate::parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char, BASE64_ENGINE};
 
 /// This type represents all possible errors that can occur when
 /// serializing or deserializing RON data.
@@ -303,7 +303,7 @@ impl de::Error for Error {
                     Char(c) => write!(f, "the UTF-8 character `{}`", c),
                     Str(s) => write!(f, "the string {:?}", s),
                     Bytes(b) => write!(f, "the bytes \"{}\"", {
-                        base64::display::Base64Display::from(b, &base64::engine::DEFAULT_ENGINE)
+                        base64::display::Base64Display::new(b, &BASE64_ENGINE)
                     }),
                     Unit => write!(f, "a unit value"),
                     Option => write!(f, "an optional value"),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,10 +5,14 @@ use std::{
     str::{from_utf8, from_utf8_unchecked, FromStr},
 };
 
+use base64::engine::general_purpose::{GeneralPurpose, STANDARD};
+
 use crate::{
     error::{Error, Position, Result, SpannedError, SpannedResult},
     extensions::Extensions,
 };
+
+pub const BASE64_ENGINE: GeneralPurpose = STANDARD;
 
 // We have the following char categories.
 const INT_CHAR: u8 = 1 << 0; // [0-9A-Fa-f_]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,12 +1,16 @@
 use std::io;
 
+use base64::Engine;
 use serde::{ser, Deserialize, Serialize};
 
 use crate::{
     error::{Error, Result},
     extensions::Extensions,
     options::Options,
-    parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char, LargeSInt, LargeUInt},
+    parse::{
+        is_ident_first_char, is_ident_other_char, is_ident_raw_char, LargeSInt, LargeUInt,
+        BASE64_ENGINE,
+    },
 };
 
 mod raw;
@@ -566,7 +570,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        self.serialize_str(base64::encode(v).as_str())
+        self.serialize_str(BASE64_ENGINE.encode(v).as_str())
     }
 
     fn serialize_none(self) -> Result<()> {


### PR DESCRIPTION
I've bumped base64 to 0.21 and refactored its usage by defining the used engine, `STANDARD`, as a private const in one place.

Supersedes #432

* [x] I've included my change in `CHANGELOG.md`
