### PR TITLE
Switch from `base64` to `data-encoding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `escape_strings` option to `PrettyConfig` to allow serialising with or without escaping ([#426](https://github.com/ron-rs/ron/pull/426))
 - Bump MSRV to 1.57.0 and bump dependency: `base64` to 0.20 ([#431](https://github.com/ron-rs/ron/pull/431))
 - Bump dependency `base64` to 0.21 ([#433](https://github.com/ron-rs/ron/pull/433))
+- Switch from `base64` to `data-encoding` ([#434](https://github.com/ron-rs/ron/pull/434))
 
 ## [0.8.0] - 2022-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 integer128 = []
 
 [dependencies]
-base64 = "0.21"
+data-encoding = "2"
 bitflags = "1.3"
 indexmap = { version = "1.9", features = ["serde-1"], optional = true }
 # serde supports i128/u128 from 1.0.60 onwards

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86fd10d912cab78764cc44307d9cd5f164e09abbeb87fb19fb6d95937e8da5f"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +22,12 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "jobserver"
@@ -83,8 +83,8 @@ dependencies = [
 name = "ron"
 version = "0.8.0"
 dependencies = [
- "base64",
  "bitflags",
+ "data-encoding",
  "serde",
 ]
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,7 +1,6 @@
 /// Deserialization module.
 use std::{borrow::Cow, io, str};
 
-use base64::Engine;
 use serde::de::{self, DeserializeSeed, Deserializer as SerdeError, Visitor};
 
 use self::{id::IdDeserializer, tag::TagDeserializer};
@@ -10,7 +9,7 @@ use crate::{
     error::{Result, SpannedResult},
     extensions::Extensions,
     options::Options,
-    parse::{AnyNum, Bytes, ParsedStr, BASE64_ENGINE},
+    parse::{AnyNum, Bytes, ParsedStr},
 };
 
 mod id;
@@ -404,7 +403,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 ParsedStr::Allocated(ref s) => s.as_str(),
                 ParsedStr::Slice(s) => s,
             };
-            BASE64_ENGINE.decode(base64_str)
+            data_encoding::BASE64.decode(base64_str.as_bytes())
         };
 
         match res {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Err
 
 use serde::{de, ser};
 
-use crate::parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char, BASE64_ENGINE};
+use crate::parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char};
 
 /// This type represents all possible errors that can occur when
 /// serializing or deserializing RON data.
@@ -20,7 +20,7 @@ pub type SpannedResult<T> = std::result::Result<T, SpannedError>;
 pub enum Error {
     Io(String),
     Message(String),
-    Base64Error(base64::DecodeError),
+    Base64Error(data_encoding::DecodeError),
     Eof,
     ExpectedArray,
     ExpectedArrayEnd,
@@ -302,9 +302,7 @@ impl de::Error for Error {
                     Float(n) => write!(f, "the floating point number `{}`", n),
                     Char(c) => write!(f, "the UTF-8 character `{}`", c),
                     Str(s) => write!(f, "the string {:?}", s),
-                    Bytes(b) => write!(f, "the bytes \"{}\"", {
-                        base64::display::Base64Display::new(b, &BASE64_ENGINE)
-                    }),
+                    Bytes(b) => write!(f, "the bytes \"{}\"", data_encoding::BASE64.encode(b)),
                     Unit => write!(f, "a unit value"),
                     Option => write!(f, "an optional value"),
                     NewtypeStruct => write!(f, "a newtype struct"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -443,3 +443,19 @@ impl<'a> fmt::Display for Identifier<'a> {
         }
     }
 }
+
+#[test]
+fn test_unexpected_bytes() {
+    use crate::de::from_str;
+
+    assert_eq!(
+        Err(SpannedError {
+            code: Error::InvalidValueForType {
+                expected: "a borrowed byte array".into(),
+                found: "the bytes \"AQI=\"".into(),
+            },
+            position: Position { line: 1, col: 7 }
+        }),
+        from_str::<&serde_bytes::Bytes>("\"AQI=\"")
+    );
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,14 +5,10 @@ use std::{
     str::{from_utf8, from_utf8_unchecked, FromStr},
 };
 
-use base64::engine::general_purpose::{GeneralPurpose, STANDARD};
-
 use crate::{
     error::{Error, Position, Result, SpannedError, SpannedResult},
     extensions::Extensions,
 };
-
-pub const BASE64_ENGINE: GeneralPurpose = STANDARD;
 
 // We have the following char categories.
 const INT_CHAR: u8 = 1 << 0; // [0-9A-Fa-f_]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,16 +1,12 @@
 use std::io;
 
-use base64::Engine;
 use serde::{ser, Deserialize, Serialize};
 
 use crate::{
     error::{Error, Result},
     extensions::Extensions,
     options::Options,
-    parse::{
-        is_ident_first_char, is_ident_other_char, is_ident_raw_char, LargeSInt, LargeUInt,
-        BASE64_ENGINE,
-    },
+    parse::{is_ident_first_char, is_ident_other_char, is_ident_raw_char, LargeSInt, LargeUInt},
 };
 
 mod raw;
@@ -570,7 +566,7 @@ impl<'a, W: io::Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        self.serialize_str(BASE64_ENGINE.encode(v).as_str())
+        self.serialize_str(data_encoding::BASE64.encode(v).as_str())
     }
 
     fn serialize_none(self) -> Result<()> {

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -121,6 +121,16 @@ fn test_byte_stream() {
         "(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)"
     );
 
+    // Requires padding of the base64 data
+    let large = vec![0x01, 0x02, 0x03, 0x04];
+    let large = serde_bytes::Bytes::new(&large);
+    assert_eq!(to_string(&large).unwrap(), "\"AQIDBA==\"");
+
+    // Requires no padding of the base64 data
+    let large = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+    let large = serde_bytes::Bytes::new(&large);
+    assert_eq!(to_string(&large).unwrap(), "\"AQIDBAUG\"");
+
     let large = vec![255u8; 64];
     let large = serde_bytes::Bytes::new(&large);
     assert_eq!(


### PR DESCRIPTION
It offers the same functionality and provides a simpler API that provides exactly what is needed here.


* [x] I've included my change in `CHANGELOG.md`
