### PR TITLE
depend on `serde_derive` separately for more compilation parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `escape_strings` option to `PrettyConfig` to allow serialising with or without escaping ([#426](https://github.com/ron-rs/ron/pull/426))
 - Bump MSRV to 1.57.0 and bump dependency: `base64` to 0.20 ([#431](https://github.com/ron-rs/ron/pull/431))
 - Bump dependency `base64` to 0.21 ([#433](https://github.com/ron-rs/ron/pull/433))
+- Depend on `serde_derive` directly to potentially enable more compilation parallelism ([#441](https://github.com/ron-rs/ron/pull/441))
 
 ## [0.8.0] - 2022-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,11 @@ base64 = "0.21"
 bitflags = "1.3"
 indexmap = { version = "1.9", features = ["serde-1"], optional = true }
 # serde supports i128/u128 from 1.0.60 onwards
-serde = { version = "1.0.60", features = ["serde_derive"] }
+serde = "1.0.60"
+serde_derive = "1.0"
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0"
 bitflags-serial = { git = "https://github.com/kvark/bitflags-serial" }

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use serde_bytes;
+use serde_derive::Deserialize;
 
 use crate::{
     de::from_str,

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 bitflags::bitflags! {
     #[derive(Serialize, Deserialize)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -2,7 +2,8 @@
 
 use std::io;
 
-use serde::{de, ser, Deserialize, Serialize};
+use serde::{de, ser};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::{
     de::Deserializer,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,7 +1,8 @@
 use std::io;
 
 use base64::Engine;
-use serde::{ser, Deserialize, Serialize};
+use serde::{ser, ser::Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::{
     error::{Error, Result},

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde_derive::Serialize;
 
 use super::to_string;
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -9,8 +9,9 @@ use std::{
 
 use serde::{
     de::{DeserializeOwned, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor},
-    forward_to_deserialize_any, Deserialize, Serialize,
+    forward_to_deserialize_any,
 };
+use serde_derive::{Deserialize, Serialize};
 
 use crate::{de::Error, error::Result};
 


### PR DESCRIPTION
* [x] I've included my change in `CHANGELOG.md`

If no crate enables the `derive` feature of `serde`, then `serde` and `serde_derive` can compile in parallel, and anything depending only on `serde` can compile while `serde_derive` is not yet done.
This can save up to 5 seconds of compilation, depending on whether this helps the critical chain and if no other crate enables the feature. 


![image](https://user-images.githubusercontent.com/22177966/224720751-3bdebf5a-a620-45d1-89d2-4f4a90a609a2.png)
