### PR TITLE
Upgrade to bitflags 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Depend on `serde_derive` directly to potentially enable more compilation parallelism ([#441](https://github.com/ron-rs/ron/pull/441))
 - Add `compact_maps` and `compact_structs` options to `PrettyConfig` to allow serialising maps and structs on a single line ([#448](https://github.com/ron-rs/ron/pull/448))
 - Add minimal support for `#[serde(flatten)]` with roundtripping through RON maps ([#455](https://github.com/ron-rs/ron/pull/455))
+- Breaking: Bump `bitflags` dependency to 2.0, `Extensions` is now `u64`-sized ([#443](https://github.com/ron-rs/ron/pull/443))
 
 ## [0.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Depend on `serde_derive` directly to potentially enable more compilation parallelism ([#441](https://github.com/ron-rs/ron/pull/441))
 - Add `compact_maps` and `compact_structs` options to `PrettyConfig` to allow serialising maps and structs on a single line ([#448](https://github.com/ron-rs/ron/pull/448))
 - Add minimal support for `#[serde(flatten)]` with roundtripping through RON maps ([#455](https://github.com/ron-rs/ron/pull/455))
-- Breaking: Bump `bitflags` dependency to 2.0, `Extensions` is now `u64`-sized ([#443](https://github.com/ron-rs/ron/pull/443))
+- Breaking: Bump `bitflags` dependency to 2.0, changes `serde` impls of `Extensions` ([#443](https://github.com/ron-rs/ron/pull/443))
 
 ## [0.8.0] - 2022-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ integer128 = []
 
 [dependencies]
 base64 = "0.21"
-bitflags = "1.3"
+bitflags = { version = "2.0", features = ["serde"] }
 indexmap = { version = "1.9", features = ["serde-1"], optional = true }
 # serde supports i128/u128 from 1.0.60 onwards
 serde = "1.0.60"
@@ -35,5 +35,4 @@ serde_derive = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0"
-bitflags-serial = { git = "https://github.com/kvark/bitflags-serial" }
 option_set = "0.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,51 +4,54 @@ version = 3
 
 [[package]]
 name = "arbitrary"
-version = "1.1.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86fd10d912cab78764cc44307d9cd5f164e09abbeb87fb19fb6d95937e8da5f"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "f4f6e5df9abedba5099a01a6567c6086a6fbcff57af07c360d356737f9e0c644"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae185684fe19814afd066da15a7cc41e126886c21282934225d9fc847582da58"
+checksum = "beb09950ae85a0a94b27676cccf37da5ff13f27076aa1adbc6545dd0d0e1bd4e"
 dependencies = [
  "arbitrary",
  "cc",
@@ -57,24 +60,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -86,6 +89,7 @@ dependencies = [
  "base64",
  "bitflags",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -98,18 +102,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
-dependencies = [
- "serde_derive",
-]
+checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -118,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -129,6 +130,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
-version = "2.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f6e5df9abedba5099a01a6567c6086a6fbcff57af07c360d356737f9e0c644"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
 dependencies = [
  "serde",
 ]
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -66,9 +66,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -102,15 +102,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.155"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use base64::Engine;
-use serde::de::{self, DeserializeSeed, Deserializer as SerdeError, Visitor};
+use serde::de::{self, DeserializeSeed, Deserializer as _, Visitor};
 
 use self::{id::IdDeserializer, tag::TagDeserializer};
 pub use crate::error::{Error, Position, SpannedError};

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -2,7 +2,7 @@ use serde_derive::{Deserialize, Serialize};
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-    pub struct Extensions: u64 {
+    pub struct Extensions: usize {
         const UNWRAP_NEWTYPES = 0x1;
         const IMPLICIT_SOME = 0x2;
         const UNWRAP_VARIANT_NEWTYPES = 0x4;

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,8 +1,8 @@
 use serde_derive::{Deserialize, Serialize};
 
 bitflags::bitflags! {
-    #[derive(Serialize, Deserialize)]
-    pub struct Extensions: usize {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+    pub struct Extensions: u64 {
         const UNWRAP_NEWTYPES = 0x1;
         const IMPLICIT_SOME = 0x2;
         const UNWRAP_VARIANT_NEWTYPES = 0x4;

--- a/src/value/raw.rs
+++ b/src/value/raw.rs
@@ -125,7 +125,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a RawValue {
             }
 
             fn visit_borrowed_str<E: de::Error>(self, ron: &'de str) -> Result<Self::Value, E> {
-                match Options::default().from_str::<serde::de::IgnoredAny>(ron) {
+                match Options::default().from_str::<de::IgnoredAny>(ron) {
                     Ok(_) => Ok(RawValue::from_borrowed_str(ron)),
                     Err(err) => Err(de::Error::custom(format!(
                         "invalid RON value at {}: {}",
@@ -159,7 +159,7 @@ impl<'de> Deserialize<'de> for Box<RawValue> {
             }
 
             fn visit_str<E: de::Error>(self, ron: &str) -> Result<Self::Value, E> {
-                match Options::default().from_str::<serde::de::IgnoredAny>(ron) {
+                match Options::default().from_str::<de::IgnoredAny>(ron) {
                     Ok(_) => Ok(RawValue::from_boxed_str(ron.to_owned().into_boxed_str())),
                     Err(err) => Err(de::Error::custom(format!(
                         "invalid RON value at {}: {}",
@@ -169,7 +169,7 @@ impl<'de> Deserialize<'de> for Box<RawValue> {
             }
 
             fn visit_string<E: de::Error>(self, ron: String) -> Result<Self::Value, E> {
-                match Options::default().from_str::<serde::de::IgnoredAny>(&ron) {
+                match Options::default().from_str::<de::IgnoredAny>(&ron) {
                     Ok(_) => Ok(RawValue::from_boxed_str(ron.into_boxed_str())),
                     Err(err) => Err(de::Error::custom(format!(
                         "invalid RON value at {}: {}",

--- a/tests/152_bitflags.rs
+++ b/tests/152_bitflags.rs
@@ -1,11 +1,11 @@
 use bitflags::*;
 use option_set::option_set;
 
-#[macro_use]
-extern crate bitflags_serial;
-
 bitflags! {
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash,
+        serde::Serialize, serde::Deserialize,
+    )]
     struct TestGood: u8 {
         const ONE = 1;
         const TWO = 1 << 1;
@@ -14,15 +14,8 @@ bitflags! {
 }
 
 option_set! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     struct TestBad: UpperCamel + u8 {
-        const ONE = 1;
-        const TWO = 1 << 1;
-        const THREE  = 1 << 2;
-    }
-}
-
-bitflags_serial! {
-    struct TestBadTWO: u8 {
         const ONE = 1;
         const TWO = 1 << 1;
         const THREE  = 1 << 2;
@@ -39,8 +32,8 @@ fn test_bitflags() {
     let json_ser_good = serde_json::ser::to_string(&flag_good).unwrap();
     let ron_ser_good = ron::ser::to_string(&flag_good).unwrap();
 
-    assert_eq!(json_ser_good, "{\"bits\":3}");
-    assert_eq!(ron_ser_good, "(bits:3)");
+    assert_eq!(json_ser_good, "\"ONE | TWO\"");
+    assert_eq!(ron_ser_good, "(\"ONE | TWO\")");
 
     let json_de_good: TestGood = serde_json::de::from_str(json_ser_good.as_str()).unwrap();
     let ron_de_good: TestGood = ron::de::from_str(ron_ser_good.as_str()).unwrap();
@@ -62,19 +55,4 @@ fn test_bitflags() {
 
     assert_eq!(json_de_bad, flag_bad);
     assert_eq!(ron_de_bad, flag_bad);
-
-    // bitflags_serial
-    let flag_bad_two = TestBadTWO::ONE | TestBadTWO::TWO;
-
-    let json_ser_bad_two = serde_json::ser::to_string(&flag_bad_two).unwrap();
-    let ron_ser_bad_two = ron::ser::to_string(&flag_bad_two).unwrap();
-
-    assert_eq!(json_ser_bad_two, "[\"ONE\",\"TWO\"]");
-    assert_eq!(ron_ser_bad_two, "[ONE,TWO]");
-
-    let json_de_bad_two: TestBadTWO = serde_json::de::from_str(json_ser_bad_two.as_str()).unwrap();
-    let ron_de_bad_two: TestBadTWO = ron::de::from_str(ron_ser_bad_two.as_str()).unwrap();
-
-    assert_eq!(json_de_bad_two, flag_bad_two);
-    assert_eq!(ron_de_bad_two, flag_bad_two);
 }


### PR DESCRIPTION
Supersedes #442. Updates the `bitflags` dependency to 2.0

Breaking change:
- `bitflags` 2.0 serializes differently, now using the names instead of `(bits: 42)`. Did we ever commit to how `Extensions` is serialized?

@kvark [`bitflags-serial`](https://github.com/kvark/bitflags-serial) still uses `bitflags` 1.0, so I've removed the related test for now. Feel free to re-add it or ping me once `bitflags-serial` is updated

* [x] I've included my change in `CHANGELOG.md`
