### PR TITLE
Support unicode idents (matching rust)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ indexmap = { version = "1.9", features = ["serde-1"], optional = true }
 # serde supports i128/u128 from 1.0.60 onwards
 serde = "1.0.60"
 serde_derive = "1.0"
+unicode-ident = "1.0.8"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -17,7 +17,7 @@ RON = [extensions], ws, value, ws;
 
 ```ebnf
 ws = { ws_single | comment };
-ws_single = "\n" | "\t" | "\r" | " ";
+ws_single = "\n" | "\t" | "\r" | " " | U+000B | U+000C | U+0085 | U+200E | U+200F | U+2028 | U+2029;
 comment = ["//", { no_newline }, "\n"] | ["/*", nested_block_comment, "*/"];
 nested_block_comment = { ? any characters except "/*" or "*/" ? }, [ "/*", nested_block_comment, "*/", nested_block_comment ];
 ```
@@ -145,8 +145,10 @@ enum_variant_named = ident, ws, "(", [named_field, { comma, named_field }, [comm
 ```ebnf
 ident = ident_std | ident_raw;
 ident_std = ident_std_first, { ident_std_rest };
-ident_std_first = "A" | ... | "Z" | "a" | ... | "z" | "_";
-ident_std_rest = ident_std_first | digit;
+ident_std_first = XID_Start | "_";
+ident_std_rest = XID_Continue;
 ident_raw = "r", "#", ident_raw_rest, { ident_raw_rest };
 ident_raw_rest = ident_std_rest | "." | "+" | "-";
 ```
+
+> Note: [XID_Start](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B%3AXID_Start%3A%5D&abb=on&g=&i=) and [XID_Continue](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B%3AXID_Continue%3A%5D&abb=on&g=&i=) refer to Unicode character sets.

--- a/examples/decode_file.rs
+++ b/examples/decode_file.rs
@@ -23,7 +23,7 @@ struct Nested {
 
 fn main() {
     let input_path = format!("{}/examples/example.ron", env!("CARGO_MANIFEST_DIR"));
-    let f = File::open(&input_path).expect("Failed opening file");
+    let f = File::open(input_path).expect("Failed opening file");
     let config: Config = match from_reader(f) {
         Ok(x) => x,
         Err(e) => {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -242,7 +242,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             return self.handle_any_struct(visitor);
         }
 
-        match self.bytes.peek_or_eof()? {
+        match self.bytes.peek_byte_or_eof()? {
             b'(' => self.handle_any_struct(visitor),
             b'[' => self.deserialize_seq(visitor),
             b'{' => self.deserialize_map(visitor),
@@ -686,7 +686,7 @@ impl<'a, 'de> CommaSeparated<'a, 'de> {
 
         match (
             self.had_comma,
-            self.de.bytes.peek_or_eof()? != self.terminator,
+            self.de.bytes.peek_byte_or_eof()? != self.terminator,
         ) {
             // Trailing comma, maybe has a next element
             (true, has_element) => Ok(has_element),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -142,7 +142,7 @@ impl<'de> Deserializer<'de> {
         V: Visitor<'de>,
     {
         // Create a working copy
-        let mut bytes = self.parser;
+        let mut bytes = self.parser.clone();
 
         if bytes.consume_str("(") {
             bytes.skip_ws()?;
@@ -237,10 +237,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             return visitor.visit_f64(std::f64::NAN);
         }
 
-        // `identifier` does not change state if it fails
-        let ident = self.parser.identifier().ok();
-
-        if ident.is_some() {
+        if self.parser.skip_ident() {
             self.parser.skip_ws()?;
 
             return self.handle_any_struct(visitor);

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -125,7 +125,7 @@ impl<'de> Deserializer<'de> {
     pub fn end(&mut self) -> Result<()> {
         self.parser.skip_ws()?;
 
-        if dbg!(self.parser).src().is_empty() {
+        if self.parser.src().is_empty() {
             Ok(())
         } else {
             Err(Error::TrailingCharacters)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -143,7 +143,7 @@ impl<'de> Deserializer<'de> {
         // Create a working copy
         let mut bytes = self.parser.clone();
 
-        if bytes.consume_str("(") {
+        if bytes.consume_char('(') {
             bytes.skip_ws()?;
 
             if bytes.check_tuple_struct()? {
@@ -173,7 +173,7 @@ impl<'de> Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if self.newtype_variant || self.parser.consume_str("(") {
+        if self.newtype_variant || self.parser.consume_char('(') {
             let old_newtype_variant = self.newtype_variant;
             self.newtype_variant = false;
 
@@ -194,7 +194,7 @@ impl<'de> Deserializer<'de> {
 
             self.parser.skip_ws()?;
 
-            if old_newtype_variant || self.parser.consume_str(")") {
+            if old_newtype_variant || self.parser.consume_char(')') {
                 Ok(value)
             } else {
                 Err(Error::ExpectedStructLikeEnd)
@@ -424,7 +424,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             visitor.visit_none()
         } else if self.parser.consume_str("Some") && {
             self.parser.skip_ws()?;
-            self.parser.consume_str("(")
+            self.parser.consume_char('(')
         } {
             self.parser.skip_ws()?;
 
@@ -432,7 +432,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
             self.parser.comma()?;
 
-            if self.parser.consume_str(")") {
+            if self.parser.consume_char(')') {
                 Ok(v)
             } else {
                 Err(Error::ExpectedOptionEnd)
@@ -499,12 +499,12 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         self.parser.skip_ws()?;
 
-        if self.parser.consume_str("(") {
+        if self.parser.consume_char('(') {
             self.parser.skip_ws()?;
             let value = guard_recursion! { self => visitor.visit_newtype_struct(&mut *self)? };
             self.parser.comma()?;
 
-            if self.parser.consume_str(")") {
+            if self.parser.consume_char(')') {
                 Ok(value)
             } else {
                 Err(Error::ExpectedStructLikeEnd)
@@ -522,13 +522,13 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         self.newtype_variant = false;
 
-        if self.parser.consume_str("[") {
+        if self.parser.consume_char('[') {
             let value = guard_recursion! { self =>
                 visitor.visit_seq(CommaSeparated::new(']', self))?
             };
             self.parser.skip_ws()?;
 
-            if self.parser.consume_str("]") {
+            if self.parser.consume_char(']') {
                 Ok(value)
             } else {
                 Err(Error::ExpectedArrayEnd)
@@ -542,7 +542,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if self.newtype_variant || self.parser.consume_str("(") {
+        if self.newtype_variant || self.parser.consume_char('(') {
             let old_newtype_variant = self.newtype_variant;
             self.newtype_variant = false;
 
@@ -551,7 +551,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             };
             self.parser.skip_ws()?;
 
-            if old_newtype_variant || self.parser.consume_str(")") {
+            if old_newtype_variant || self.parser.consume_char(')') {
                 Ok(value)
             } else {
                 Err(Error::ExpectedStructLikeEnd)
@@ -586,13 +586,13 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         self.newtype_variant = false;
 
-        if self.parser.consume_str("{") {
+        if self.parser.consume_char('{') {
             let value = guard_recursion! { self =>
                 visitor.visit_map(CommaSeparated::new('}', self))?
             };
             self.parser.skip_ws()?;
 
-            if self.parser.consume_str("}") {
+            if self.parser.consume_char('}') {
                 Ok(value)
             } else {
                 Err(Error::ExpectedMapEnd)
@@ -739,7 +739,7 @@ impl<'de, 'a> de::MapAccess<'de> for CommaSeparated<'a, 'de> {
     {
         self.de.parser.skip_ws()?;
 
-        if self.de.parser.consume_str(":") {
+        if self.de.parser.consume_char(':') {
             self.de.parser.skip_ws()?;
 
             let res = guard_recursion! { self.de =>
@@ -796,7 +796,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
 
         self.de.parser.skip_ws()?;
 
-        if self.de.parser.consume_str("(") {
+        if self.de.parser.consume_char('(') {
             self.de.parser.skip_ws()?;
 
             self.de.newtype_variant = self
@@ -815,7 +815,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
 
             self.de.parser.comma()?;
 
-            if self.de.parser.consume_str(")") {
+            if self.de.parser.consume_char(')') {
                 Ok(val)
             } else {
                 Err(Error::ExpectedStructLikeEnd)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -313,7 +313,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i128(self.bytes.signed_integer()?)
+        visitor.visit_i128(self.parser.signed_integer()?)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -349,7 +349,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u128(self.bytes.unsigned_integer()?)
+        visitor.visit_u128(self.parser.unsigned_integer()?)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -62,7 +62,6 @@ impl<'de> Deserializer<'de> {
     }
 
     pub fn remainder(&self) -> Cow<'_, str> {
-        // FIXME this does not make sense with the unicode validation on creation
         Cow::Borrowed(self.parser.src())
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -269,7 +269,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             '.' => self.deserialize_f64(visitor),
             '"' | 'r' => self.deserialize_string(visitor),
             '\'' => self.deserialize_char(visitor),
-            other => Err(Error::UnexpectedChar(other as char)),
+            other => Err(Error::UnexpectedChar(other)),
         }
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -651,7 +651,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let identifier = str::from_utf8(self.bytes.identifier()?).map_err(Error::from)?;
+        let identifier = self.bytes.identifier()?;
 
         self.last_identifier = Some(identifier);
 

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -4,7 +4,7 @@ use serde_derive::Deserialize;
 use crate::{
     de::from_str,
     error::{Error, Position, SpannedError, SpannedResult},
-    parse::{AnyNum, Bytes},
+    parse::{AnyNum, Parser},
 };
 
 #[derive(Debug, PartialEq, Deserialize)]
@@ -346,7 +346,7 @@ fn test_numbers() {
 }
 
 fn de_any_number(s: &str) -> AnyNum {
-    let mut bytes = Bytes::new(s.as_bytes()).unwrap();
+    let mut bytes = Parser::new(s).unwrap();
 
     bytes.any_num().unwrap()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,6 +98,7 @@ pub enum Error {
     SuggestRawIdentifier(String),
     ExpectedRawValue,
     ExceededRecursionLimit,
+    NoCharBoundary,
 }
 
 impl fmt::Display for SpannedError {
@@ -258,6 +259,7 @@ impl fmt::Display for Error {
             ),
             Error::ExpectedRawValue => f.write_str("Expected a `ron::value::RawValue`"),
             Error::ExceededRecursionLimit => f.write_str("Exceeded recursion limit, try increasing the limit and using `serde_stacker` to protect against a stack overflow"),
+            Error::NoCharBoundary => f.write_str("Tried to index source inside of char boundry"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,7 +98,6 @@ pub enum Error {
     SuggestRawIdentifier(String),
     ExpectedRawValue,
     ExceededRecursionLimit,
-    NoCharBoundary,
 }
 
 impl fmt::Display for SpannedError {
@@ -259,7 +258,6 @@ impl fmt::Display for Error {
             ),
             Error::ExpectedRawValue => f.write_str("Expected a `ron::value::RawValue`"),
             Error::ExceededRecursionLimit => f.write_str("Exceeded recursion limit, try increasing the limit and using `serde_stacker` to protect against a stack overflow"),
-            Error::NoCharBoundary => f.write_str("Tried to index source inside of char boundry"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ pub enum Error {
 
     UnclosedBlockComment,
     UnderscoreAtBeginning,
-    UnexpectedByte(char),
+    UnexpectedChar(char),
 
     Utf8Error(Utf8Error),
     TrailingCharacters,
@@ -167,7 +167,7 @@ impl fmt::Display for Error {
             Error::UnderscoreAtBeginning => {
                 f.write_str("Unexpected leading underscore in an integer")
             }
-            Error::UnexpectedByte(ref byte) => write!(f, "Unexpected byte {:?}", byte),
+            Error::UnexpectedChar(c) => write!(f, "Unexpected char {c:?}"),
             Error::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
             Error::InvalidValueForType {
                 ref expected,

--- a/src/error.rs
+++ b/src/error.rs
@@ -166,7 +166,7 @@ impl fmt::Display for Error {
             Error::UnderscoreAtBeginning => {
                 f.write_str("Unexpected leading underscore in an integer")
             }
-            Error::UnexpectedChar(c) => write!(f, "Unexpected char {c:?}"),
+            Error::UnexpectedChar(c) => write!(f, "Unexpected char {:?}", c),
             Error::TrailingCharacters => f.write_str("Non-whitespace trailing characters"),
             Error::InvalidValueForType {
                 ref expected,

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -11,11 +11,11 @@ bitflags::bitflags! {
 
 impl Extensions {
     /// Creates an extension flag from an ident.
-    pub fn from_ident(ident: &[u8]) -> Option<Extensions> {
+    pub fn from_ident(ident: &str) -> Option<Extensions> {
         match ident {
-            b"unwrap_newtypes" => Some(Extensions::UNWRAP_NEWTYPES),
-            b"implicit_some" => Some(Extensions::IMPLICIT_SOME),
-            b"unwrap_variant_newtypes" => Some(Extensions::UNWRAP_VARIANT_NEWTYPES),
+            "unwrap_newtypes" => Some(Extensions::UNWRAP_NEWTYPES),
+            "implicit_some" => Some(Extensions::IMPLICIT_SOME),
+            "unwrap_variant_newtypes" => Some(Extensions::UNWRAP_VARIANT_NEWTYPES),
             _ => None,
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -58,11 +58,11 @@ const ENCODINGS: [u8; 256] = [
 ];
 
 const fn is_int_char(c: u8) -> bool {
-    ENCODINGS[c as usize] & INT_CHAR != 0
+    c.is_ascii_hexdigit() || c == b'_'
 }
 
 const fn is_float_char(c: u8) -> bool {
-    ENCODINGS[c as usize] & FLOAT_CHAR != 0
+    c.is_ascii_digit() || matches!(c, b'e'|b'E'|b'.'|b'+'|b'-')
 }
 
 pub fn is_ident_first_char(c: char) -> bool {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -115,12 +115,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn advance(&mut self, bytes: usize) -> Result<()> {
-        let mut idx = 0;
-        while idx < bytes {
-            idx += self.advance_char()?;
+    pub fn advance(&mut self, mut bytes: usize) -> Result<()> {
+        while bytes > 0 {
+            bytes -= self.advance_char()?;
         }
-        debug_assert_eq!(idx, bytes, "bytes are a valid unicode boundry");
 
         Ok(())
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -723,9 +723,9 @@ impl<'a> Parser<'a> {
     }
 
     pub fn string(&mut self) -> Result<ParsedStr<'a>> {
-        if self.consume_str("\"") {
+        if self.consume_char('"') {
             self.escaped_string()
-        } else if self.consume_str("r") {
+        } else if self.consume_char('r') {
             self.raw_string()
         } else {
             Err(Error::ExpectedString)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -363,7 +363,6 @@ impl<'a> Parser<'a> {
             let max_i64 = LargeSInt::from(std::i64::MAX);
 
             if is_signed {
-                // TODO should a `+ u128::MAX` be allowed?
                 match self.signed_integer::<LargeSInt>() {
                     Ok(x) => {
                         if x >= min_i8 && x <= max_i8 {
@@ -589,8 +588,6 @@ impl<'a> Parser<'a> {
     }
 
     pub fn skip_ident(&mut self) -> bool {
-        // If normal ident, first char must be `is_ident_first_char`
-        // If raw ident, first char must be `r`, which is `is_ident_first_char`
         if let Ok(c) = self.peek() {
             if c == 'r' {
                 match self.peek2() {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -326,13 +326,13 @@ impl<W: io::Write> Serializer<W> {
     fn separate_tuple_members(&self) -> bool {
         self.pretty
             .as_ref()
-            .map_or(false, |&(ref config, _)| config.separate_tuple_members)
+            .map_or(false, |(config, _)| config.separate_tuple_members)
     }
 
     fn compact_arrays(&self) -> bool {
         self.pretty
             .as_ref()
-            .map_or(false, |&(ref config, _)| config.compact_arrays)
+            .map_or(false, |(config, _)| config.compact_arrays)
     }
 
     fn extensions(&self) -> Extensions {
@@ -340,13 +340,13 @@ impl<W: io::Write> Serializer<W> {
             | self
                 .pretty
                 .as_ref()
-                .map_or(Extensions::empty(), |&(ref config, _)| config.extensions)
+                .map_or(Extensions::empty(), |(config, _)| config.extensions)
     }
 
     fn escape_strings(&self) -> bool {
         self.pretty
             .as_ref()
-            .map_or(true, |&(ref config, _)| config.escape_strings)
+            .map_or(true, |(config, _)| config.escape_strings)
     }
 
     fn start_indent(&mut self) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -9,10 +9,7 @@ use crate::{
     error::{Error, Result},
     extensions::Extensions,
     options::Options,
-    parse::{
-        is_ident_first_char, is_ident_raw_char, LargeSInt, LargeUInt,
-        BASE64_ENGINE,
-    },
+    parse::{is_ident_first_char, is_ident_raw_char, LargeSInt, LargeUInt, BASE64_ENGINE},
 };
 
 mod raw;

--- a/tests/321_unicode_ident.rs
+++ b/tests/321_unicode_ident.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+enum EnumWithUnicode {
+    Äöß,
+    你好世界,
+}
+
+#[test]
+fn roundtrip_unicode_ident() {
+    let value = [EnumWithUnicode::Äöß, EnumWithUnicode::你好世界];
+    let serial = ron::ser::to_string(&value).unwrap();
+
+    println!("Serialized: {}", serial);
+
+    let deserial = ron::de::from_str(&serial);
+
+    assert_eq!(Ok(value), deserial);
+}

--- a/tests/407_raw_value.rs
+++ b/tests/407_raw_value.rs
@@ -55,7 +55,7 @@ fn test_raw_value_invalid() {
     assert_eq!(
         err,
         SpannedError {
-            code: Error::UnexpectedByte('\0'),
+            code: Error::UnexpectedChar('\0'),
             position: Position { line: 1, col: 1 }
         }
     )
@@ -145,7 +145,7 @@ fn test_raw_value_serde_json() {
             .unwrap_err();
     assert_eq!(
         err.to_string(),
-        "invalid RON value at 1:13: Unexpected byte ')' at line 1 column 39"
+        "invalid RON value at 1:13: Unexpected char ')' at line 1 column 39"
     );
 
     let err = serde_json::from_str::<WithRawValue>("{\"a\":true,\"b\":42}").unwrap_err();
@@ -157,7 +157,7 @@ fn test_raw_value_serde_json() {
     let err = serde_json::from_str::<&RawValue>("\"/* hi */ (a:) /* bye */\"").unwrap_err();
     assert_eq!(
         err.to_string(),
-        "invalid RON value at 1:13: Unexpected byte ')' at line 1 column 25"
+        "invalid RON value at 1:13: Unexpected char ')' at line 1 column 25"
     );
 
     let err = serde_json::from_str::<&RawValue>("42").unwrap_err();

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -32,12 +32,12 @@ fn test_ascii_10() {
 
 #[test]
 fn test_ascii_chars() {
-    (1..128).into_iter().flat_map(from_u32).for_each(check_same)
+    (1..128).flat_map(from_u32).for_each(check_same)
 }
 
 #[test]
 fn test_ascii_string() {
-    let s: String = (1..128).into_iter().flat_map(from_u32).collect();
+    let s: String = (1..128).flat_map(from_u32).collect();
 
     check_same(s);
 }

--- a/tests/struct_integers.rs
+++ b/tests/struct_integers.rs
@@ -33,7 +33,6 @@ fn roundtrip() {
         j: std::u128::MAX,
     };
     let serialized = ron::ser::to_string(&s).unwrap();
-    dbg!(&serialized);
     let deserialized = ron::de::from_str(&serialized).unwrap();
     assert_eq!(s, deserialized,);
 }

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -1,4 +1,8 @@
-use ron::de::from_str;
+use ron::{
+    de::{from_bytes, from_str},
+    error::Position,
+    Error, Value,
+};
 
 #[test]
 fn test_char() {
@@ -10,4 +14,14 @@ fn test_char() {
 fn test_string() {
     let de: String = from_str("\"My string: ऄ\"").unwrap();
     assert_eq!(de, "My string: ऄ");
+}
+
+#[test]
+fn test_file_invalid_unicode() {
+    let error = from_bytes::<Value>(&[b'\n', b'a', 0b11000000, 0]).unwrap_err();
+    assert!(matches!(error.code, Error::Utf8Error(_)));
+    assert_eq!(error.position, Position { line: 2, col: 2 });
+    let error = from_bytes::<Value>(&[b'\n', b'\n', 0b11000000]).unwrap_err();
+    assert!(matches!(error.code, Error::Utf8Error(_)));
+    assert_eq!(error.position, Position { line: 3, col: 1 });
 }

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -17,6 +17,11 @@ fn test_string() {
 }
 
 #[test]
+fn ident_starts_with_non_ascii_byte() {
+    let _ = from_str::<Value>("שּׁȬSSSSSSSSSSR");
+}
+
+#[test]
 fn test_file_invalid_unicode() {
     let error = from_bytes::<Value>(&[b'\n', b'a', 0b11000000, 0]).unwrap_err();
     assert!(matches!(error.code, Error::Utf8Error(_)));


### PR DESCRIPTION
* [ ] I've included my change in `CHANGELOG.md`

This not only changes the ident parsing, but also uses `&str` instead of `&[u8]`
for the rest of the parsing (sometime as a byte slice through `.bytes()`).

If you prefer to have a more restricted implementation that only changes
`.*ident*()` methods on `Bytes` I can revert the other changes and use
`from_utf8_unchecked` instead.

But as I saw that the benchmark using this implementation was more or less on
par with the current implementation I wanted to share it at least:

`ron-new` is this PR's string based implementation, `ron` is the current git
version.

```
Benchmarking Serde Deserialization/json/data/canada: Warming up for 3.0000 s
Warning: Unable to complete 10000 samples in 5.0s. You may wish to increase target time to 89.8s, or reduce sample count to 550.
Serde Deserialization/json/data/canada
                        time:   [8.9827 ms 8.9938 ms 9.0056 ms]
                        change: [-3.4193% -2.9076% -2.4310%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 860 outliers among 10000 measurements (8.60%)
  1 (0.01%) low mild
  493 (4.93%) high mild
  366 (3.66%) high severe
Benchmarking Serde Deserialization/ron/data/canada: Warming up for 3.0000 s
Warning: Unable to complete 10000 samples in 5.0s. You may wish to increase target time to 317.2s, or reduce sample count to 150.
Serde Deserialization/ron/data/canada
                        time:   [31.000 ms 31.028 ms 31.056 ms]
                        change: [-1.5615% -1.2462% -0.9532%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 521 outliers among 10000 measurements (5.21%)
  209 (2.09%) high mild
  312 (3.12%) high severe
Benchmarking Serde Deserialization/ron-new/data/canada: Warming up for 3.0000 s
Warning: Unable to complete 10000 samples in 5.0s. You may wish to increase target time to 320.1s, or reduce sample count to 150.
Serde Deserialization/ron-new/data/canada
                        time:   [30.619 ms 30.638 ms 30.658 ms]
                        change: [-2.9465% -2.7434% -2.5733%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 164 outliers among 10000 measurements (1.64%)
  63 (0.63%) high mild
  101 (1.01%) high severe
```

I also didn't add any tests yet.

fixes #321 