### PR TITLE
Add `compact_maps` and `compact_structs` options to `PrettyConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump MSRV to 1.57.0 and bump dependency: `base64` to 0.20 ([#431](https://github.com/ron-rs/ron/pull/431))
 - Bump dependency `base64` to 0.21 ([#433](https://github.com/ron-rs/ron/pull/433))
 - Depend on `serde_derive` directly to potentially enable more compilation parallelism ([#441](https://github.com/ron-rs/ron/pull/441))
+- Add `compact_maps` and `compact_structs` options to `PrettyConfig` to allow serialising maps and structs on a single line ([#448](https://github.com/ron-rs/ron/pull/448))
 
 ## [0.8.0] - 2022-08-17
 

--- a/tests/447_compact_maps_structs.rs
+++ b/tests/447_compact_maps_structs.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeMap;
+
+use ron::ser::{to_string, to_string_pretty, PrettyConfig};
+
+#[derive(serde_derive::Serialize)]
+struct Struct {
+    a: u8,
+    b: u8,
+}
+
+#[test]
+fn compact_structs() {
+    let s = Struct { a: 4, b: 2 };
+
+    assert_eq!(to_string(&s).unwrap(), "(a:4,b:2)");
+    assert_eq!(
+        to_string_pretty(&s, PrettyConfig::default()).unwrap(),
+        "(\n    a: 4,\n    b: 2,\n)"
+    );
+    assert_eq!(
+        to_string_pretty(&s, PrettyConfig::default().compact_structs(true)).unwrap(),
+        "(a: 4, b: 2)"
+    );
+}
+
+#[test]
+fn compact_maps() {
+    let m: BTreeMap<&str, i32> = BTreeMap::from_iter([("a", 4), ("b", 2)].into_iter());
+
+    assert_eq!(to_string(&m).unwrap(), "{\"a\":4,\"b\":2}");
+    assert_eq!(
+        to_string_pretty(&m, PrettyConfig::default()).unwrap(),
+        "{\n    \"a\": 4,\n    \"b\": 2,\n}"
+    );
+    assert_eq!(
+        to_string_pretty(&m, PrettyConfig::default().compact_maps(true)).unwrap(),
+        "{\"a\": 4, \"b\": 2}"
+    );
+}


### PR DESCRIPTION
Fixes #447 by adding `compact_maps` and `compact_structs` options to `PrettyConfig`

* [x] I've included my change in `CHANGELOG.md`
