### PR TITLE
Add minimal support for flattening roundtrips through maps

### DIFF
--- a/tests/115_minimal_flattening.rs
+++ b/tests/115_minimal_flattening.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct Main {
+    #[serde(flatten)]
+    required: Required,
+    #[serde(flatten)]
+    optional: Optional,
+
+    some_other_field: u32,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct Required {
+    first: u32,
+    second: u32,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct Optional {
+    third: Option<u32>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct MyType {
+    first: u32,
+    second: u32,
+    #[serde(flatten)]
+    everything_else: HashMap<String, ron::Value>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct AllOptional {
+    #[serde(flatten)]
+    everything_else: HashMap<String, ron::Value>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+enum Newtype {
+    Main(Main),
+    MyType(MyType),
+    AllOptional(AllOptional),
+}
+
+#[test]
+fn test_flatten_struct_into_struct() {
+    let val = Main {
+        required: Required {
+            first: 1,
+            second: 2,
+        },
+        optional: Optional { third: Some(3) },
+        some_other_field: 1337,
+    };
+
+    let ron = ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default()).unwrap();
+
+    assert_eq!(
+        ron,
+        "{
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": Some(3),
+    \"some_other_field\": 1337,
+}"
+    );
+
+    let de: Main = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+
+    let val = Newtype::Main(Main {
+        required: Required {
+            first: 1,
+            second: 2,
+        },
+        optional: Optional { third: Some(3) },
+        some_other_field: 1337,
+    });
+
+    let ron = ron::ser::to_string_pretty(
+        &val,
+        ron::ser::PrettyConfig::default()
+            .extensions(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ron,
+        "#![enable(unwrap_variant_newtypes)]
+Main({
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": Some(3),
+    \"some_other_field\": 1337,
+})"
+    );
+
+    let ron = ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default()).unwrap();
+
+    let de: Newtype = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+}
+
+#[test]
+fn test_flatten_rest() {
+    let val = MyType {
+        first: 1,
+        second: 2,
+        everything_else: {
+            let mut map = HashMap::new();
+            map.insert(
+                String::from("third"),
+                ron::Value::Number(ron::value::Number::from(3)),
+            );
+            map
+        },
+    };
+
+    let ron = ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default()).unwrap();
+
+    assert_eq!(
+        ron,
+        "{
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": 3,
+}"
+    );
+
+    let de: MyType = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+
+    let val = Newtype::MyType(MyType {
+        first: 1,
+        second: 2,
+        everything_else: {
+            let mut map = HashMap::new();
+            map.insert(
+                String::from("third"),
+                ron::Value::Number(ron::value::Number::from(3)),
+            );
+            map
+        },
+    });
+
+    let ron = ron::ser::to_string_pretty(
+        &val,
+        ron::ser::PrettyConfig::default()
+            .extensions(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ron,
+        "#![enable(unwrap_variant_newtypes)]
+MyType({
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": 3,
+})"
+    );
+
+    let de: Newtype = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+}
+
+#[test]
+fn test_flatten_only_rest() {
+    let val = AllOptional {
+        everything_else: HashMap::new(),
+    };
+
+    let ron = ron::ser::to_string(&val).unwrap();
+
+    assert_eq!(ron, "{}");
+
+    let de: AllOptional = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+
+    let val = Newtype::AllOptional(AllOptional {
+        everything_else: HashMap::new(),
+    });
+
+    let ron = ron::ser::to_string_pretty(
+        &val,
+        ron::ser::PrettyConfig::default()
+            .extensions(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ron,
+        "#![enable(unwrap_variant_newtypes)]
+AllOptional({
+})"
+    );
+
+    let de: Newtype = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+}


### PR DESCRIPTION
Alternative to #403 which adds minimal support for `#[serde(flatten)]` to RON. Instead of many workarounds to make flattened structs serialise into nice RON struct syntax and deserialise from them, both of which are really difficult since serde gives us no information to work with and just delegates to map serialisation/deserialisation, this PR just ensures that at least flattened structs can roundtrip through RON.

For this, just one hack is necessary. Map keys that request identifiers can now be deserialised from strings, sort of. But only if they are written exactly as `"`, identifier, `"`. This seems to be enough to get the tests to work that I initially designed for #403.

@torkleyy I'd be in favour of landing this instead of going down the rabbit hole of #403 since that just fixes one of the two parts and getting flattened structs to serialise correctly would require hacks of another order.

This would not really fix #115 but at least get some working if imperfect solution.

* [ ] I've included my change in `CHANGELOG.md`
