### PR TITLE
Add minimal support for flattening roundtrips through maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump dependency `base64` to 0.21 ([#433](https://github.com/ron-rs/ron/pull/433))
 - Depend on `serde_derive` directly to potentially enable more compilation parallelism ([#441](https://github.com/ron-rs/ron/pull/441))
 - Add `compact_maps` and `compact_structs` options to `PrettyConfig` to allow serialising maps and structs on a single line ([#448](https://github.com/ron-rs/ron/pull/448))
+- Add minimal support for `#[serde(flatten)]` with roundtripping ([#455](https://github.com/ron-rs/ron/pull/455))
 
 ## [0.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump dependency `base64` to 0.21 ([#433](https://github.com/ron-rs/ron/pull/433))
 - Depend on `serde_derive` directly to potentially enable more compilation parallelism ([#441](https://github.com/ron-rs/ron/pull/441))
 - Add `compact_maps` and `compact_structs` options to `PrettyConfig` to allow serialising maps and structs on a single line ([#448](https://github.com/ron-rs/ron/pull/448))
-- Add minimal support for `#[serde(flatten)]` with roundtripping ([#455](https://github.com/ron-rs/ron/pull/455))
+- Add minimal support for `#[serde(flatten)]` with roundtripping through RON maps ([#455](https://github.com/ron-rs/ron/pull/455))
 
 ## [0.8.0] - 2022-08-17
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Note the following advantages of RON over JSON:
 RON is not designed to be a fully self-describing format (unlike JSON) and is thus not guaranteed to work when [`deserialize_any`](https://docs.rs/serde/latest/serde/trait.Deserializer.html#tymethod.deserialize_any) is used instead of its typed alternatives. In particular, the following Serde attributes are not yet supported:
 - `#[serde(tag = "type")]`, i.e. internally tagged enums
 - `#[serde(untagged)]`, i.e. untagged enums
-- `#[serde(flatten)]`, i.e. flattening an inner struct into its outer container
+
+Furthermore, `#[serde(flatten)]` only has limited support. Specifically, flattened structs are only serialised as maps and deserialised from maps. However, this limited implementation supports full roundtripping.
 
 ## RON syntax overview
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ RON is not designed to be a fully self-describing format (unlike JSON) and is th
 - `#[serde(tag = "type")]`, i.e. internally tagged enums
 - `#[serde(untagged)]`, i.e. untagged enums
 
-Furthermore, `#[serde(flatten)]` only has limited support. Specifically, flattened structs are only serialised as maps and deserialised from maps. However, this limited implementation supports full roundtripping.
+Furthermore, `#[serde(flatten)]` only has limited support and relies on a small hack [^serde-flatten-hack]. Specifically, flattened structs are only serialised as maps and deserialised from maps. However, this limited implementation supports full roundtripping.
+
+[^serde-flatten-hack]: Deserialising a flattened struct from a map requires that the struct's [`Visitor::expecting`](https://docs.rs/serde/latest/serde/de/trait.Visitor.html#tymethod.expecting) implementation formats a string starting with `"struct "`. This is the case for automatically-derived [`Deserialize`](https://docs.rs/serde/latest/serde/de/trait.Deserialize.html) impls on structs.
 
 ## RON syntax overview
 

--- a/src/de/id.rs
+++ b/src/de/id.rs
@@ -21,11 +21,11 @@ impl<'a, 'b: 'a, 'c> de::Deserializer<'b> for &'c mut IdDeserializer<'a, 'b> {
         V: Visitor<'b>,
     {
         if self.map_as_struct {
-            self.d.bytes.consume("\"");
+            self.d.bytes.expect_byte(b'"', Error::ExpectedString)?;
         }
         let result = self.d.deserialize_identifier(visitor);
         if self.map_as_struct {
-            self.d.bytes.consume("\"");
+            self.d.bytes.expect_byte(b'"', Error::ExpectedStringEnd)?;
         }
         result
     }

--- a/src/de/id.rs
+++ b/src/de/id.rs
@@ -4,11 +4,12 @@ use super::{Deserializer, Error, Result};
 
 pub struct IdDeserializer<'a, 'b: 'a> {
     d: &'a mut Deserializer<'b>,
+    map_as_struct: bool,
 }
 
 impl<'a, 'b: 'a> IdDeserializer<'a, 'b> {
-    pub fn new(d: &'a mut Deserializer<'b>) -> Self {
-        IdDeserializer { d }
+    pub fn new(map_as_struct: bool, d: &'a mut Deserializer<'b>) -> Self {
+        IdDeserializer { d, map_as_struct }
     }
 }
 
@@ -19,7 +20,14 @@ impl<'a, 'b: 'a, 'c> de::Deserializer<'b> for &'c mut IdDeserializer<'a, 'b> {
     where
         V: Visitor<'b>,
     {
-        self.d.deserialize_identifier(visitor)
+        if self.map_as_struct {
+            self.d.bytes.consume("\"");
+        }
+        let result = self.d.deserialize_identifier(visitor);
+        if self.map_as_struct {
+            self.d.bytes.consume("\"");
+        }
+        result
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -601,10 +601,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         self.newtype_variant = false;
 
-        let mut buffer = [0u8; SERDE_FLATTEN_CANARY.len()];
-        let mut cursor = std::io::Cursor::new(&mut buffer as &mut [u8]);
-        let _ = write!(cursor, "{}", VisitorExpecting(&visitor));
-        let terminator = if buffer == SERDE_FLATTEN_CANARY {
+        let mut canary_buffer = [0u8; SERDE_FLATTEN_CANARY.len()];
+        let _ = write!(canary_buffer.as_mut(), "{}", VisitorExpecting(&visitor));
+        let terminator = if canary_buffer == SERDE_FLATTEN_CANARY {
             Terminator::MapAsStruct
         } else {
             Terminator::Map

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -176,7 +176,7 @@ impl<'de> Deserializer<'de> {
 
             let value = guard_recursion! { self =>
                 visitor
-                    .visit_map(CommaSeparated::new(b')', self))
+                    .visit_map(CommaSeparated::new(Terminator::Struct, self))
                     .map_err(|err| {
                         struct_error_name(
                             err,
@@ -525,7 +525,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         if self.bytes.consume("[") {
             let value = guard_recursion! { self =>
-                visitor.visit_seq(CommaSeparated::new(b']', self))?
+                visitor.visit_seq(CommaSeparated::new(Terminator::Seq, self))?
             };
             self.bytes.skip_ws()?;
 
@@ -548,7 +548,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             self.newtype_variant = false;
 
             let value = guard_recursion! { self =>
-                visitor.visit_seq(CommaSeparated::new(b')', self))?
+                visitor.visit_seq(CommaSeparated::new(Terminator::Tuple, self))?
             };
             self.bytes.skip_ws()?;
 
@@ -587,9 +587,22 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         self.newtype_variant = false;
 
+        struct VisitorExpecting<V>(V);
+        impl<'de, V: Visitor<'de>> std::fmt::Display for VisitorExpecting<&'_ V> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.expecting(f)
+            }
+        }
+
+        let terminator = if VisitorExpecting(&visitor).to_string().starts_with("struct ") {
+            Terminator::MapAsStruct
+        } else {
+            Terminator::Map
+        };
+
         if self.bytes.consume("{") {
             let value = guard_recursion! { self =>
-                visitor.visit_map(CommaSeparated::new(b'}', self))?
+                visitor.visit_map(CommaSeparated::new(terminator, self))?
             };
             self.bytes.skip_ws()?;
 
@@ -666,14 +679,28 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Terminator {
+    Map, MapAsStruct, Tuple, Struct, Seq
+}
+impl Terminator {
+    fn as_byte(self) -> u8 {
+        match self {
+            Terminator::Map | Terminator::MapAsStruct => b'}',
+            Terminator::Tuple | Terminator::Struct => b')',
+            Terminator::Seq => b']',
+        }
+    }
+}
+
 struct CommaSeparated<'a, 'de: 'a> {
     de: &'a mut Deserializer<'de>,
-    terminator: u8,
+    terminator: Terminator,
     had_comma: bool,
 }
 
 impl<'a, 'de> CommaSeparated<'a, 'de> {
-    fn new(terminator: u8, de: &'a mut Deserializer<'de>) -> Self {
+    fn new(terminator: Terminator, de: &'a mut Deserializer<'de>) -> Self {
         CommaSeparated {
             de,
             terminator,
@@ -686,7 +713,7 @@ impl<'a, 'de> CommaSeparated<'a, 'de> {
 
         match (
             self.had_comma,
-            self.de.bytes.peek_or_eof()? != self.terminator,
+            self.de.bytes.peek_or_eof()? != self.terminator.as_byte(),
         ) {
             // Trailing comma, maybe has a next element
             (true, has_element) => Ok(has_element),
@@ -725,12 +752,17 @@ impl<'de, 'a> de::MapAccess<'de> for CommaSeparated<'a, 'de> {
         K: DeserializeSeed<'de>,
     {
         if self.has_element()? {
-            if self.terminator == b')' {
-                guard_recursion! { self.de =>
-                    seed.deserialize(&mut IdDeserializer::new(&mut *self.de)).map(Some)
-                }
-            } else {
-                guard_recursion! { self.de => seed.deserialize(&mut *self.de).map(Some) }
+            match self.terminator {
+                Terminator::Struct =>
+                    guard_recursion! { self.de =>
+                        seed.deserialize(&mut IdDeserializer::new(false, &mut *self.de)).map(Some)
+                    },
+                Terminator::MapAsStruct =>
+                    guard_recursion! { self.de =>
+                        seed.deserialize(&mut IdDeserializer::new(true, &mut *self.de)).map(Some)
+                    },
+                _ =>
+                    guard_recursion! { self.de => seed.deserialize(&mut *self.de).map(Some) },
             }
         } else {
             Ok(None)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -601,9 +601,10 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         self.newtype_variant = false;
 
-        let mut cursor = std::io::Cursor::new([0u8; SERDE_FLATTEN_CANARY.len()]);
+        let mut buffer = [0u8; SERDE_FLATTEN_CANARY.len()];
+        let mut cursor = std::io::Cursor::new(&mut buffer as &mut [u8]);
         let _ = write!(cursor, "{}", VisitorExpecting(&visitor));
-        let terminator = if cursor.into_inner() == SERDE_FLATTEN_CANARY {
+        let terminator = if buffer == SERDE_FLATTEN_CANARY {
             Terminator::MapAsStruct
         } else {
             Terminator::Map

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -696,6 +696,7 @@ enum Terminator {
     Struct,
     Seq,
 }
+
 impl Terminator {
     fn as_byte(self) -> u8 {
         match self {

--- a/tests/115_minimal_flattening.rs
+++ b/tests/115_minimal_flattening.rs
@@ -103,6 +103,66 @@ Main({
     let de: Newtype = ron::from_str(&ron).unwrap();
 
     assert_eq!(de, val);
+
+    assert_eq!(
+        ron::from_str::<Main>(
+            "{
+        first\": 1,
+        \"second\": 2,
+        \"third\": Some(3),
+        \"some_other_field\": 1337,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedString,
+            position: ron::error::Position { line: 2, col: 10 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<Main>(
+            "{
+        \"first\": 1,
+        \"second: 2,
+        \"third\": Some(3),
+        \"some_other_field\": 1337,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedStringEnd,
+            position: ron::error::Position { line: 3, col: 17 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<Main>(
+            "{
+        \"first\": 1,
+        \"second\": 2,
+        third\": Some(3),
+        \"some_other_field\": 1337,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedString,
+            position: ron::error::Position { line: 4, col: 10 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<Main>(
+            "{
+        \"first\": 1,
+        \"second\": 2,
+        \"third\": Some(3),
+        \"some_other_field: 1337,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedStringEnd,
+            position: ron::error::Position { line: 5, col: 27 },
+        })
+    );
 }
 
 #[test]
@@ -168,6 +228,62 @@ MyType({
     let de: Newtype = ron::from_str(&ron).unwrap();
 
     assert_eq!(de, val);
+
+    assert_eq!(
+        ron::from_str::<MyType>(
+            "{
+        first\": 1,
+        \"second\": 2,
+        \"third\": 3,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedString,
+            position: ron::error::Position { line: 2, col: 10 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<MyType>(
+            "{
+        \"first\": 1,
+        \"second: 2,
+        \"third\": 3,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedStringEnd,
+            position: ron::error::Position { line: 3, col: 17 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<MyType>(
+            "{
+        \"first\": 1,
+        \"second\": 2,
+        third\": 3,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedString,
+            position: ron::error::Position { line: 4, col: 10 },
+        })
+    );
+
+    assert_eq!(
+        ron::from_str::<MyType>(
+            "{
+        \"first\": 1,
+        \"second\": 2,
+        \"third: 3,
+    }"
+        ),
+        Err(ron::error::SpannedError {
+            code: ron::error::Error::ExpectedStringEnd,
+            position: ron::error::Position { line: 4, col: 16 },
+        })
+    );
 }
 
 #[test]

--- a/tests/115_minimal_flattening.rs
+++ b/tests/115_minimal_flattening.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct Main {
+    #[serde(flatten)]
+    required: Required,
+    #[serde(flatten)]
+    optional: Optional,
+
+    some_other_field: u32,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct Required {
+    first: u32,
+    second: u32,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct Optional {
+    third: Option<u32>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct MyType {
+    first: u32,
+    second: u32,
+    #[serde(flatten)]
+    everything_else: HashMap<String, ron::Value>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+struct AllOptional {
+    #[serde(flatten)]
+    everything_else: HashMap<String, ron::Value>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+enum Newtype {
+    Main(Main),
+    MyType(MyType),
+    AllOptional(AllOptional),
+}
+
+#[test]
+fn test_flatten_struct_into_struct() {
+    let val = Main {
+        required: Required {
+            first: 1,
+            second: 2,
+        },
+        optional: Optional { third: Some(3) },
+        some_other_field: 1337,
+    };
+
+    let ron = ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default()).unwrap();
+
+    assert_eq!(
+        ron,
+        "{
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": Some(3),
+    \"some_other_field\": 1337,
+}"
+    );
+
+    let de: Main = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+
+    let val = Newtype::Main(Main {
+        required: Required {
+            first: 1,
+            second: 2,
+        },
+        optional: Optional { third: Some(3) },
+        some_other_field: 1337,
+    });
+
+    let ron = ron::ser::to_string_pretty(
+        &val,
+        ron::ser::PrettyConfig::default()
+            .extensions(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ron,
+        "#![enable(unwrap_variant_newtypes)]
+Main({
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": Some(3),
+    \"some_other_field\": 1337,
+})"
+    );
+
+    let ron = ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default()).unwrap();
+
+    let de: Newtype = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+}
+
+#[test]
+fn test_flatten_rest() {
+    let val = MyType {
+        first: 1,
+        second: 2,
+        everything_else: {
+            let mut map = HashMap::new();
+            map.insert(
+                String::from("third"),
+                ron::Value::Number(ron::value::Number::from(3)),
+            );
+            map
+        },
+    };
+
+    let ron = ron::ser::to_string_pretty(&val, ron::ser::PrettyConfig::default()).unwrap();
+
+    assert_eq!(
+        ron,
+        "{
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": 3,
+}"
+    );
+
+    let de: MyType = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+
+    let val = Newtype::MyType(MyType {
+        first: 1,
+        second: 2,
+        everything_else: {
+            let mut map = HashMap::new();
+            map.insert(
+                String::from("third"),
+                ron::Value::Number(ron::value::Number::from(3)),
+            );
+            map
+        },
+    });
+
+    let ron = ron::ser::to_string_pretty(
+        &val,
+        ron::ser::PrettyConfig::default()
+            .extensions(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ron,
+        "#![enable(unwrap_variant_newtypes)]
+MyType({
+    \"first\": 1,
+    \"second\": 2,
+    \"third\": 3,
+})"
+    );
+
+    let de: Newtype = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+}
+
+#[test]
+fn test_flatten_only_rest() {
+    let val = AllOptional {
+        everything_else: HashMap::new(),
+    };
+
+    let ron = ron::ser::to_string(&val).unwrap();
+
+    assert_eq!(ron, "{}");
+
+    let de: AllOptional = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+
+    let val = Newtype::AllOptional(AllOptional {
+        everything_else: HashMap::new(),
+    });
+
+    let ron = ron::ser::to_string_pretty(
+        &val,
+        ron::ser::PrettyConfig::default()
+            .extensions(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ron,
+        "#![enable(unwrap_variant_newtypes)]
+AllOptional({
+})"
+    );
+
+    let de: Newtype = ron::from_str(&ron).unwrap();
+
+    assert_eq!(de, val);
+}


### PR DESCRIPTION
Supersedes #403, #453, and #454 to add minimal support for `#[serde(flatten)]` in RON. Instead of many workarounds to make flattened structs serialise into nice RON struct syntax and deserialise from them, both of which are really difficult since serde gives us no information to work with and just delegates to map serialisation/deserialisation, this PR just ensures that at least flattened structs can roundtrip through RON.

For this, just one hack is necessary. If we detect that a map is deserialised into what looks like a struct (thanks @clouds56 for contributing the detection in #454), we enforce that map key identifiers are actually strings written exactly as `"`, identifier, `"`. This seems to be enough to get the tests to work that I initially designed for https://github.com/ron-rs/ron/pull/403.

@torkleyy I'd be in favour of landing this instead of going down the rabbit hole of https://github.com/ron-rs/ron/pull/403 since that just fixes one of the two parts and getting flattened structs to serialise correctly would require hacks of another order.

This would not really fix https://github.com/ron-rs/ron/issues/115 but at least get some working if imperfect solution.

* [x] Add tests for the new error cases, i.e. when flattening goes wrong
* [x] I've included my change in `CHANGELOG.md`
