### PR TITLE
Fix benchmark CI cargo install

### DIFF
--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -21,7 +21,7 @@ jobs:
           mkdir -p fuzz/corpus/arbitrary
           unzip public.zip -d fuzz/corpus/arbitrary
           rm public.zip
-      - uses: boa-dev/criterion-compare-action@v3
+      - uses: juntyr/criterion-compare-action@check-cargo-install
         with:
           cwd: fuzz
           benchName: bench


### PR DESCRIPTION
Fix the `cargo install critcmp` error in the benchmark CI

~~* [ ] I've included my change in `CHANGELOG.md`~~
