### PR TITLE
Try slightly modified codecov CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,12 +89,19 @@ jobs:
           mkdir -p "${HOME}/.local/bin"
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.18/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - name: Generate coverage report
+      - name: Generate the coverage data
         run: |
           cargo test --all-targets
           cargo test --features integer128 --all-targets
           cargo test --features indexmap --all-targets
           cargo test --all-features --all-targets
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -Cinstrument-coverage
+          RUSTDOCFLAGS: -Cinstrument-coverage
+          LLVM_PROFILE_FILE: codecov-%p-%m.profraw
+      - name: Generate the coverage reports
+        run: |
           grcov . -s . --binary-path ./target/debug/deps \
             -t lcov -o codecov.lcov --branch \
             --keep-only "src/*" \
@@ -103,13 +110,30 @@ jobs:
             --excl-line GRCOV_EXCL_LINE \
             --excl-start GRCOV_EXCL_START \
             --excl-stop GRCOV_EXCL_STOP
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -Cinstrument-coverage
-          RUSTDOCFLAGS: -Cinstrument-coverage
-          LLVM_PROFILE_FILE: codecov-%p-%m.profraw
-      - name: Upload coverage report
-        uses: coverallsapp/github-action@v2
+          grcov . -s . --binary-path ./target/debug/deps \
+            -t html --branch \
+            --keep-only "src/*" \
+            --keep-only "tests/*" \
+            --ignore-not-existing \
+            --excl-line GRCOV_EXCL_LINE \
+            --excl-start GRCOV_EXCL_START \
+            --excl-stop GRCOV_EXCL_STOP
+          rm -rf html/badges
+      - name: Summarise code coverage
+        uses: romeovs/lcov-reporter-action@v0.2.16
         with:
-          file: codecov.lcov
-          fail-on-error: true
+          lcov-file: codecov.lcov
+        if: github.event_name == 'pull_request'
+      - name: Upload the code coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: html/
+        if: github.event_name == 'pull_request'
+      - name: Deploy the code coverage report
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./html
+          destination_dir: coverage
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       - run: cargo fmt -- --check
 
   coverage:
-    name: "Coverage: nightly"
+    name: "Coverage: stable"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -80,10 +80,15 @@ jobs:
           key: coverage
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           components: llvm-tools-preview
           override: true
+      - name: Download grcov
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.18/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - run: cargo install grcov --force
         env:
           CARGO_TARGET_DIR: target/
@@ -92,8 +97,8 @@ jobs:
           cargo test --features integer128 --all-targets
           cargo test --features indexmap --all-targets
           cargo test --all-features --all-targets
-          grcov . -s . --binary-path ./target/debug/ \
-            -t cobertura -o cobertura.xml --branch \
+          grcov . -s . --binary-path ./target/debug/deps \
+            -t lcov -o codecov.lcov --branch \
             --keep-only "src/*" \
             --keep-only "tests/*" \
             --ignore-not-existing \
@@ -101,9 +106,11 @@ jobs:
             --excl-start GRCOV_EXCL_START \
             --excl-stop GRCOV_EXCL_STOP
         env:
+          CARGO_INCREMENTAL: 0
           RUSTFLAGS: -Cinstrument-coverage
           RUSTDOCFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: codecov-%p-%m.profraw
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
+          files: codecov.lcov
           fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,14 @@ jobs:
             --excl-start GRCOV_EXCL_START \
             --excl-stop GRCOV_EXCL_STOP
           grcov . -s . --binary-path ./target/debug/deps \
+            -t covdir -o covdir.json --branch \
+            --keep-only "src/*" \
+            --keep-only "tests/*" \
+            --ignore-not-existing \
+            --excl-line GRCOV_EXCL_LINE \
+            --excl-start GRCOV_EXCL_START \
+            --excl-stop GRCOV_EXCL_STOP
+          grcov . -s . --binary-path ./target/debug/deps \
             -t html --branch \
             --keep-only "src/*" \
             --keep-only "tests/*" \
@@ -128,6 +136,20 @@ jobs:
         with:
           name: coverage
           path: html/
+        if: github.event_name == 'pull_request'
+      - name: Generate the coverage report summary
+        uses: ecliptical/covdir-report-action@v0.1
+        with:
+          file: covdir.json
+          summary: 'true'
+          out: coverage.md
+        if: github.event_name == 'pull_request'
+      - name: Report coverage summary to the PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          path: coverage.md
         if: github.event_name == 'pull_request'
       - name: Summarise the code coverage
         uses: romeovs/lcov-reporter-action@v0.2.16

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,16 +119,17 @@ jobs:
             --excl-start GRCOV_EXCL_START \
             --excl-stop GRCOV_EXCL_STOP
           rm -rf html/badges
-      - name: Summarise code coverage
-        uses: romeovs/lcov-reporter-action@v0.2.16
-        with:
-          lcov-file: codecov.lcov
-        if: github.event_name == 'pull_request'
       - name: Upload the code coverage report
         uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: html/
+        if: github.event_name == 'pull_request'
+      - name: Summarise the code coverage
+        uses: romeovs/lcov-reporter-action@v0.2.16
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: codecov.lcov
         if: github.event_name == 'pull_request'
       - name: Deploy the code coverage report
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,11 +89,12 @@ jobs:
           mkdir -p "${HOME}/.local/bin"
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.18/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - run: |
-          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --all-targets
-          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --features integer128 --all-targets
-          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --features indexmap --all-targets
-          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --all-features --all-targets
+      - name: Generate coverage report
+        run: |
+          cargo test --all-targets
+          cargo test --features integer128 --all-targets
+          cargo test --features indexmap --all-targets
+          cargo test --all-features --all-targets
           grcov . -s . --binary-path ./target/debug/deps \
             -t lcov -o codecov.lcov --branch \
             --keep-only "src/*" \
@@ -107,7 +108,8 @@ jobs:
           RUSTFLAGS: -Cinstrument-coverage
           RUSTDOCFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: codecov-%p-%m.profraw
-      - uses: codecov/codecov-action@v3
+      - name: Upload coverage report
+        uses: coverallsapp/github-action@v2
         with:
-          files: codecov.lcov
-          fail_ci_if_error: true
+          file: codecov.lcov
+          fail-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,9 +89,6 @@ jobs:
           mkdir -p "${HOME}/.local/bin"
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.18/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - run: cargo install grcov --force
-        env:
-          CARGO_TARGET_DIR: target/
       - run: |
           cargo test --all-targets
           cargo test --features integer128 --all-targets

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,10 +90,10 @@ jobs:
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.18/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - run: |
-          cargo test --all-targets
-          cargo test --features integer128 --all-targets
-          cargo test --features indexmap --all-targets
-          cargo test --all-features --all-targets
+          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --all-targets
+          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --features integer128 --all-targets
+          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --features indexmap --all-targets
+          CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" RUSTDOCFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="codecov-%p-%m.profraw" cargo test --all-features --all-targets
           grcov . -s . --binary-path ./target/debug/deps \
             -t lcov -o codecov.lcov --branch \
             --keep-only "src/*" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,6 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   tests:
     name: Tests
@@ -115,14 +111,6 @@ jobs:
             --excl-start GRCOV_EXCL_START \
             --excl-stop GRCOV_EXCL_STOP
           grcov . -s . --binary-path ./target/debug/deps \
-            -t covdir -o covdir.json --branch \
-            --keep-only "src/*" \
-            --keep-only "tests/*" \
-            --ignore-not-existing \
-            --excl-line GRCOV_EXCL_LINE \
-            --excl-start GRCOV_EXCL_START \
-            --excl-stop GRCOV_EXCL_STOP
-          grcov . -s . --binary-path ./target/debug/deps \
             -t html --branch \
             --keep-only "src/*" \
             --keep-only "tests/*" \
@@ -131,31 +119,17 @@ jobs:
             --excl-start GRCOV_EXCL_START \
             --excl-stop GRCOV_EXCL_STOP
           rm -rf html/badges
+      - name: Summarise the code coverage
+        uses: 06393993/lcov-reporter-action@master
+        with:
+          title: Code Coverage
+          lcov-file: codecov.lcov
+          post-to: job-summary
       - name: Upload the code coverage report
         uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: html/
-        if: github.event_name == 'pull_request'
-      - name: Generate the coverage report summary
-        uses: ecliptical/covdir-report-action@v0.1
-        with:
-          file: covdir.json
-          summary: 'true'
-          out: coverage.md
-        if: github.event_name == 'pull_request'
-      - name: Report coverage summary to the PR
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          hide_and_recreate: true
-          hide_classify: "OUTDATED"
-          path: coverage.md
-        if: github.event_name == 'pull_request'
-      - name: Summarise the code coverage
-        uses: romeovs/lcov-reporter-action@v0.2.16
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: codecov.lcov
         if: github.event_name == 'pull_request'
       - name: Deploy the code coverage report
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rusty Object Notation
 
 [![CI](https://github.com/ron-rs/ron/actions/workflows/ci.yaml/badge.svg)](https://github.com/ron-rs/ron/actions/workflows/ci.yaml)
-[![Coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fron-rs.github.io%2Fron%2Fcoverage%2Fcoverage.json)](https://ron-rs.github.io/ron/coverage/)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fron-rs.github.io%2Fron%2Fcoverage%2Fcoverage.json)](https://ron-rs.github.io/ron/coverage/)
 [![Crates.io](https://img.shields.io/crates/v/ron.svg)](https://crates.io/crates/ron)
 [![MSRV](https://img.shields.io/badge/MSRV-1.64.0-orange)](https://github.com/ron-rs/ron)
 [![Docs](https://docs.rs/ron/badge.svg)](https://docs.rs/ron)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rusty Object Notation
 
 [![CI](https://github.com/ron-rs/ron/actions/workflows/ci.yaml/badge.svg)](https://github.com/ron-rs/ron/actions/workflows/ci.yaml)
-[![codecov](https://img.shields.io/codecov/c/github/ron-rs/ron/codecov?token=x4Q5KA51Ul)](https://codecov.io/gh/ron-rs/ron)
+[![Coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fron-rs.github.io%2Fron%2Fcoverage%2Fcoverage.json)](https://ron-rs.github.io/ron/coverage/)
 [![Crates.io](https://img.shields.io/crates/v/ron.svg)](https://crates.io/crates/ron)
 [![MSRV](https://img.shields.io/badge/MSRV-1.64.0-orange)](https://github.com/ron-rs/ron)
 [![Docs](https://docs.rs/ron/badge.svg)](https://docs.rs/ron)


### PR DESCRIPTION
This PR improves our code coverage generation and moves our coverage data from codecov.io to self-hosting it on GitHub pages (since the reports on codecov.io have very weird lines whereas grcov's HTML report is much better). On PRs, the HTML reports should now be accessible as artefacts, on pushes to the main branch, the coverage data is re-deployed.

~~* [ ] I've included my change in `CHANGELOG.md`~~
