### PR TITLE
Disallow unclosed line comments at the end of raw values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `number_suffixes` option to `PrettyConfig` to allow serialising numbers with their explicit type suffix, e.g. `42i32` ([#481](https://github.com/ron-rs/ron/pull/481))
 - Allow `ron::value::RawValue` to capture any whitespace to the left and right of a ron value ([#487](https://github.com/ron-rs/ron/pull/487))
 - Fix serialising reserved identifiers `true`, `false`, `Some`, `None`, `inf`[`f32`|`f64`], and `Nan`[`f32`|`f64`] ([#487](https://github.com/ron-rs/ron/pull/487))
+- Disallow unclosed line comments at the end of `ron::value::RawValue` ([#489](https://github.com/ron-rs/ron/pull/489))
 
 ## [0.8.1] - 2023-08-17
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -545,7 +545,11 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             let bytes_before = self.bytes.pre_ws_bytes();
             self.bytes.skip_ws()?;
             let _ignored = self.deserialize_ignored_any(serde::de::IgnoredAny)?;
-            self.bytes.skip_ws()?;
+
+            if self.bytes.skip_ws_check_unclosed_line_comment()? {
+                return Err(Error::UnclosedLineComment);
+            }
+
             let bytes_after = self.bytes.bytes();
 
             let ron_bytes = &bytes_before[..bytes_before.len() - bytes_after.len()];

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,7 @@ pub enum Error {
     NoSuchExtension(String),
 
     UnclosedBlockComment,
+    UnclosedLineComment,
     UnderscoreAtBeginning,
     UnexpectedByte(char),
 
@@ -164,6 +165,10 @@ impl fmt::Display for Error {
             }
             Error::Utf8Error(ref e) => fmt::Display::fmt(e, f),
             Error::UnclosedBlockComment => f.write_str("Unclosed block comment"),
+            Error::UnclosedLineComment => f.write_str(
+                "`ron::value::RawValue` cannot end in unclosed line comment, \
+                try using a block comment or adding a newline"
+            ),
             Error::UnderscoreAtBeginning => {
                 f.write_str("Unexpected leading underscore in a number")
             }

--- a/tests/407_raw_value.rs
+++ b/tests/407_raw_value.rs
@@ -252,4 +252,28 @@ fn test_fuzzer_found_issue() {
             position: Position { line: 1, col: 27 },
         })
     );
+
+    assert_eq!(
+        RawValue::from_ron("42 //"),
+        Err(SpannedError {
+            code: Error::UnclosedLineComment,
+            position: Position { line: 1, col: 6 },
+        })
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("42 //"),
+        Err(SpannedError {
+            code: Error::UnclosedLineComment,
+            position: Position { line: 1, col: 6 },
+        })
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("42 //\n"),
+        RawValue::from_ron("42 //\n")
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("42 /**/"),
+        RawValue::from_ron("42 /**/")
+    );
+    assert_eq!(ron::from_str::<&RawValue>("42 "), RawValue::from_ron("42 "));
 }


### PR DESCRIPTION
Fixes fuzzer-found issue [#61769](https://oss-fuzz.com/issue/6313074347606016), where an unclosed line comment at the end of a raw value can stop roundtripping since the line comment can comment out any following ron.

* [x] I've included my change in `CHANGELOG.md`
