### PR TITLE
Better detection of unclosed line comments for raw value

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -545,12 +545,12 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             let bytes_before = self.bytes.pre_ws_bytes();
             self.bytes.skip_ws()?;
             let _ignored = self.deserialize_ignored_any(serde::de::IgnoredAny)?;
+            self.bytes.skip_ws()?;
+            let bytes_after = self.bytes.bytes();
 
-            if self.bytes.skip_ws_check_unclosed_line_comment()? {
+            if self.bytes.has_unclosed_line_comment() {
                 return Err(Error::UnclosedLineComment);
             }
-
-            let bytes_after = self.bytes.bytes();
 
             let ron_bytes = &bytes_before[..bytes_before.len() - bytes_after.len()];
             let ron_str = str::from_utf8(ron_bytes).map_err(Error::from)?;

--- a/tests/407_raw_value.rs
+++ b/tests/407_raw_value.rs
@@ -268,12 +268,42 @@ fn test_fuzzer_found_issue() {
         })
     );
     assert_eq!(
-        ron::from_str::<&RawValue>("42 //\n"),
-        RawValue::from_ron("42 //\n")
+        ron::from_str::<&RawValue>("42 //\n").unwrap(),
+        RawValue::from_ron("42 //\n").unwrap()
     );
     assert_eq!(
-        ron::from_str::<&RawValue>("42 /**/"),
-        RawValue::from_ron("42 /**/")
+        ron::from_str::<&RawValue>("42 /**/").unwrap(),
+        RawValue::from_ron("42 /**/").unwrap()
     );
-    assert_eq!(ron::from_str::<&RawValue>("42 "), RawValue::from_ron("42 "));
+    assert_eq!(
+        ron::from_str::<&RawValue>("42 ").unwrap(),
+        RawValue::from_ron("42 ").unwrap()
+    );
+
+    assert_eq!(
+        RawValue::from_ron("a//"),
+        Err(SpannedError {
+            code: Error::UnclosedLineComment,
+            position: Position { line: 1, col: 4 },
+        })
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("a//"),
+        Err(SpannedError {
+            code: Error::UnclosedLineComment,
+            position: Position { line: 1, col: 4 },
+        })
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("a//\n").unwrap(),
+        RawValue::from_ron("a//\n").unwrap()
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("a/**/").unwrap(),
+        RawValue::from_ron("a/**/").unwrap()
+    );
+    assert_eq!(
+        ron::from_str::<&RawValue>("a").unwrap(),
+        RawValue::from_ron("a").unwrap()
+    );
 }


### PR DESCRIPTION
Follow-up to #489 since the fuzzer is always smarter

~~* [ ] I've included my change in `CHANGELOG.md`~~
