### PR TITLE
Enforce explicit `Some` around raw values

### DIFF
--- a/tests/407_raw_value.rs
+++ b/tests/407_raw_value.rs
@@ -306,4 +306,21 @@ fn test_fuzzer_found_issue() {
         ron::from_str::<&RawValue>("a").unwrap(),
         RawValue::from_ron("a").unwrap()
     );
+
+    assert_eq!(
+        ron::to_string(&Some(Some(RawValue::from_ron("None").unwrap()))).unwrap(),
+        "Some(Some(None))"
+    );
+    // Since a RawValue can contain anything, no implicit Some are allowed around it
+    assert_eq!(
+        ron::Options::default()
+            .with_default_extension(ron::extensions::Extensions::IMPLICIT_SOME)
+            .to_string(&Some(Some(RawValue::from_ron("None").unwrap())))
+            .unwrap(),
+        "Some(Some(None))"
+    );
+    assert_eq!(
+        ron::from_str::<Option<Option<&RawValue>>>("Some(Some(None))").unwrap(),
+        Some(Some(RawValue::from_ron("None").unwrap()))
+    );
 }


### PR DESCRIPTION
Since a `ron::value::RawValue` can contain anything, implicit `Some` must be made explicit around it.

~~* [ ] I've included my change in `CHANGELOG.md`~~
