### PR TITLE
`Value::from` and full code lines coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue [#321](https://github.com/ron-rs/ron/issues/321) and allow parsing UTF-8 identifiers ([#488](https://github.com/ron-rs/ron/pull/488))
 - Breaking: Enforce that ron always writes valid UTF-8 ([#488](https://github.com/ron-rs/ron/pull/488))
 - Fix parsing of struct/variant names starting in `None`, `Some`, `true`, or `false` ([#499](https://github.com/ron-rs/ron/pull/499))
+- Add convenient `Value::from` impls ([#498](https://github.com/ron-rs/ron/pull/498))
 
 ## [0.8.1] - 2023-08-17
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -172,17 +172,14 @@ impl<'de> Deserializer<'de> {
         self.serde_content_newtype = false;
 
         match (
-            match self.parser.check_struct_type(
+            self.parser.check_struct_type(
                 NewtypeMode::NoParensMeanUnit,
                 if old_serde_content_newtype {
                     TupleMode::DifferentiateNewtype // separate match on NewtypeOrTuple below
                 } else {
                     TupleMode::ImpreciseTupleOrNewtype // Tuple and NewtypeOrTuple match equally
                 },
-            ) {
-                Ok(s) => s,
-                Err(e) => panic!(),
-            },
+            )?,
             ident,
         ) {
             (StructType::Unit, Some(ident)) if is_serde_content => {
@@ -257,7 +254,6 @@ impl<'de> Deserializer<'de> {
             if old_newtype_variant || self.parser.consume_char(')') {
                 Ok(value)
             } else {
-                panic!();
                 Err(Error::ExpectedStructLikeEnd)
             }
         } else if name_for_pretty_errors_only.is_empty() {
@@ -590,10 +586,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 Err(Error::ExpectedStructLikeEnd)
             }
         } else if name.is_empty() {
-            panic!();
             Err(Error::ExpectedStructLike)
         } else {
-            panic!();
             Err(Error::ExpectedNamedStructLike(name))
         }
     }
@@ -613,7 +607,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             if self.parser.consume_char(']') {
                 Ok(value)
             } else {
-                panic!();
                 Err(Error::ExpectedArrayEnd)
             }
         } else {
@@ -658,7 +651,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
 
         self.deserialize_tuple(len, visitor).map_err(|e| match e {
-            Error::ExpectedStructLike if !name.is_empty() => panic!(), //Error::ExpectedNamedStructLike(name),
+            Error::ExpectedStructLike if !name.is_empty() => Error::ExpectedNamedStructLike(name),
             e => e,
         })
     }
@@ -700,7 +693,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             if self.parser.consume_char('}') {
                 Ok(value)
             } else {
-                panic!();
                 Err(Error::ExpectedMapEnd)
             }
         } else {
@@ -950,7 +942,6 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
                 Err(Error::ExpectedStructLikeEnd)
             }
         } else {
-            panic!();
             Err(Error::ExpectedStructLike)
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -172,14 +172,17 @@ impl<'de> Deserializer<'de> {
         self.serde_content_newtype = false;
 
         match (
-            self.parser.check_struct_type(
+            match self.parser.check_struct_type(
                 NewtypeMode::NoParensMeanUnit,
                 if old_serde_content_newtype {
                     TupleMode::DifferentiateNewtype // separate match on NewtypeOrTuple below
                 } else {
                     TupleMode::ImpreciseTupleOrNewtype // Tuple and NewtypeOrTuple match equally
                 },
-            )?,
+            ) {
+                Ok(s) => s,
+                Err(e) => panic!(),
+            },
             ident,
         ) {
             (StructType::Unit, Some(ident)) if is_serde_content => {
@@ -254,6 +257,7 @@ impl<'de> Deserializer<'de> {
             if old_newtype_variant || self.parser.consume_char(')') {
                 Ok(value)
             } else {
+                panic!();
                 Err(Error::ExpectedStructLikeEnd)
             }
         } else if name_for_pretty_errors_only.is_empty() {
@@ -586,8 +590,10 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 Err(Error::ExpectedStructLikeEnd)
             }
         } else if name.is_empty() {
+            panic!();
             Err(Error::ExpectedStructLike)
         } else {
+            panic!();
             Err(Error::ExpectedNamedStructLike(name))
         }
     }
@@ -607,6 +613,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             if self.parser.consume_char(']') {
                 Ok(value)
             } else {
+                panic!();
                 Err(Error::ExpectedArrayEnd)
             }
         } else {
@@ -651,7 +658,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
 
         self.deserialize_tuple(len, visitor).map_err(|e| match e {
-            Error::ExpectedStructLike if !name.is_empty() => Error::ExpectedNamedStructLike(name),
+            Error::ExpectedStructLike if !name.is_empty() => panic!(), //Error::ExpectedNamedStructLike(name),
             e => e,
         })
     }
@@ -693,6 +700,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             if self.parser.consume_char('}') {
                 Ok(value)
             } else {
+                panic!();
                 Err(Error::ExpectedMapEnd)
             }
         } else {
@@ -942,6 +950,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
                 Err(Error::ExpectedStructLikeEnd)
             }
         } else {
+            panic!();
             Err(Error::ExpectedStructLike)
         }
     }

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -78,6 +78,7 @@ fn test_struct() {
             position: Position { line: 1, col: 1 },
         }),
     );
+    check_from_str_bytes_reader("(33)", Ok(UnnamedNewType(33)));
     check_from_str_bytes_reader::<UnnamedNewType>(
         "Newtype",
         Err(SpannedError {
@@ -124,9 +125,11 @@ fn test_unclosed_limited_seq_struct() {
             impl<'de> serde::de::Visitor<'de> for Visitor {
                 type Value = LimitedStruct;
 
+                // GRCOV_EXCL_START
                 fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    fmt.write_str("struct LimitedStruct") // GRCOV_EXCL_LINE
+                    fmt.write_str("struct LimitedStruct")
                 }
+                // GRCOV_EXCL_STOP
 
                 fn visit_map<A: serde::de::MapAccess<'de>>(
                     self,
@@ -161,9 +164,11 @@ fn test_unclosed_limited_seq() {
             impl<'de> serde::de::Visitor<'de> for Visitor {
                 type Value = LimitedSeq;
 
+                // GRCOV_EXCL_START
                 fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    fmt.write_str("an empty sequence") // GRCOV_EXCL_LINE
+                    fmt.write_str("an empty sequence")
                 }
+                // GRCOV_EXCL_STOP
 
                 fn visit_seq<A: serde::de::SeqAccess<'de>>(
                     self,
@@ -198,9 +203,11 @@ fn test_unclosed_limited_map() {
             impl<'de> serde::de::Visitor<'de> for Visitor {
                 type Value = LimitedMap;
 
+                // GRCOV_EXCL_START
                 fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    fmt.write_str("an empty map") // GRCOV_EXCL_LINE
+                    fmt.write_str("an empty map")
                 }
+                // GRCOV_EXCL_STOP
 
                 fn visit_map<A: serde::de::MapAccess<'de>>(
                     self,

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -188,7 +188,15 @@ fn test_unclosed_limited_seq() {
             code: Error::ExpectedArrayEnd,
             position: Position { line: 1, col: 2 },
         }),
-    )
+    );
+
+    assert_eq!(
+        crate::Value::from(vec![42]).into_rust::<LimitedSeq>(),
+        Err(Error::ExpectedDifferentLength {
+            expected: String::from("a sequence of length 0"),
+            found: 1
+        })
+    );
 }
 
 #[test]
@@ -227,7 +235,15 @@ fn test_unclosed_limited_map() {
             code: Error::ExpectedMapEnd,
             position: Position { line: 1, col: 2 },
         }),
-    )
+    );
+
+    assert_eq!(
+        crate::Value::Map([("a", 42)].into_iter().collect()).into_rust::<LimitedMap>(),
+        Err(Error::ExpectedDifferentLength {
+            expected: String::from("a map of length 0"),
+            found: 1
+        })
+    );
 }
 
 #[test]

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -230,7 +230,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
             res.0.reserve_exact(cap);
         }
 
-        while let Some(entry) = map.next_entry()? {
+        while let Some(entry) = map.next_entry::<Value, Value>()? {
             res.insert(entry.0, entry.1);
         }
 

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -207,7 +207,6 @@ impl<'de> Visitor<'de> for ValueVisitor {
     {
         let mut vec = Vec::new();
         if let Some(cap) = seq.size_hint() {
-            panic!();
             vec.reserve_exact(cap);
         }
 
@@ -226,7 +225,6 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
         #[cfg(feature = "indexmap")]
         if let Some(cap) = map.size_hint() {
-            panic!();
             res.0.reserve_exact(cap);
         }
 

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -227,7 +227,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         #[cfg(feature = "indexmap")]
         if let Some(cap) = map.size_hint() {
             panic!();
-            map.reserve_exact(cap);
+            res.0.reserve_exact(cap);
         }
 
         while let Some(entry) = map.next_entry()? {

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -197,7 +197,6 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         D: Deserializer<'de>,
     {
-        panic!();
         deserializer.deserialize_any(ValueVisitor)
     }
 

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -424,5 +424,16 @@ mod tests {
                 position: crate::error::Position { line: 1, col: 4 },
             },
         );
+
+        // Check for a failure in Deserializer::check_struct_type
+        // - opening brace triggers the struct type check
+        // - unclosed block comment fails the whitespace skip
+        assert_eq!(
+            "( /*".parse::<Value>().unwrap_err(),
+            crate::error::SpannedError {
+                code: crate::Error::UnclosedBlockComment,
+                position: crate::error::Position { line: 1, col: 5 },
+            },
+        );
     }
 }

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -197,6 +197,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         D: Deserializer<'de>,
     {
+        panic!();
         deserializer.deserialize_any(ValueVisitor)
     }
 
@@ -206,6 +207,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     {
         let mut vec = Vec::new();
         if let Some(cap) = seq.size_hint() {
+            panic!();
             vec.reserve_exact(cap);
         }
 
@@ -221,6 +223,12 @@ impl<'de> Visitor<'de> for ValueVisitor {
         A: MapAccess<'de>,
     {
         let mut res: Map = Map::new();
+
+        #[cfg(feature = "indexmap")]
+        if let Some(cap) = map.size_hint() {
+            panic!();
+            map.reserve_exact(cap);
+        }
 
         while let Some(entry) = map.next_entry()? {
             res.insert(entry.0, entry.1);

--- a/src/error.rs
+++ b/src/error.rs
@@ -632,10 +632,10 @@ mod tests {
         );
         check_error_message(
             &Error::MissingStructField {
-                field: "b+c",
+                field: "",
                 outer: Some(String::from("S+T")),
             },
-            "Unexpected missing field named `r#b+c` in `r#S+T`",
+            "Unexpected missing field named \"\"_[invalid identifier] in `r#S+T`",
         );
         check_error_message(
             &Error::duplicate_field("a"),

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -34,70 +34,59 @@ impl Map {
     /// Returns the number of elements in the map.
     #[must_use]
     pub fn len(&self) -> usize {
-        // panic!();
         self.0.len()
     }
 
     /// Returns `true` if `self.len() == 0`, `false` otherwise.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        panic!();
         self.0.is_empty()
     }
 
     /// Immutably looks up an element by its `key`.
     #[must_use]
     pub fn get(&self, key: &Value) -> Option<&Value> {
-        panic!();
         self.0.get(key)
     }
 
     /// Mutably looks up an element by its `key`.
     pub fn get_mut(&mut self, key: &Value) -> Option<&mut Value> {
-        panic!();
         self.0.get_mut(key)
     }
 
     /// Inserts a new element, returning the previous element with this `key` if
     /// there was any.
-    pub fn insert(&mut self, key: Value, value: Value) -> Option<Value> {
-        // panic!();
-        self.0.insert(key, value)
+    pub fn insert(&mut self, key: impl Into<Value>, value: impl Into<Value>) -> Option<Value> {
+        self.0.insert(key.into(), value.into())
     }
 
     /// Removes an element by its `key`.
     pub fn remove(&mut self, key: &Value) -> Option<Value> {
-        panic!();
         self.0.remove(key)
     }
 
     /// Iterate all key-value pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&Value, &Value)> + DoubleEndedIterator {
-        // panic!();
         self.0.iter()
     }
 
     /// Iterate all key-value pairs mutably.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Value, &mut Value)> + DoubleEndedIterator {
-        panic!();
         self.0.iter_mut()
     }
 
     /// Iterate all keys.
     pub fn keys(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
-        // panic!();
         self.0.keys()
     }
 
     /// Iterate all values.
     pub fn values(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
-        panic!();
         self.0.values()
     }
 
     /// Iterate all values mutably.
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut Value> + DoubleEndedIterator {
-        panic!();
         self.0.values_mut()
     }
 
@@ -111,7 +100,6 @@ impl Map {
     where
         F: FnMut(&Value, &mut Value) -> bool,
     {
-        panic!();
         self.0.retain(keep);
     }
 }
@@ -127,7 +115,6 @@ impl Index<&Value> for Map {
 impl IndexMut<&Value> for Map {
     #[allow(clippy::expect_used)]
     fn index_mut(&mut self, index: &Value) -> &mut Self::Output {
-        panic!();
         self.0.get_mut(index).expect("no entry found for key")
     }
 }
@@ -142,9 +129,12 @@ impl IntoIterator for Map {
     }
 }
 
-impl FromIterator<(Value, Value)> for Map {
-    fn from_iter<T: IntoIterator<Item = (Value, Value)>>(iter: T) -> Self {
-        Map(MapInner::from_iter(iter))
+impl<K: Into<Value>, V: Into<Value>> FromIterator<(K, V)> for Map {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        Map(iter
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect())
     }
 }
 
@@ -160,7 +150,6 @@ impl Eq for Map {}
 
 impl PartialOrd for Map {
     fn partial_cmp(&self, other: &Map) -> Option<Ordering> {
-        panic!();
         self.iter().partial_cmp(other.iter())
     }
 }
@@ -173,7 +162,113 @@ impl Ord for Map {
 
 impl Hash for Map {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        panic!();
         self.iter().for_each(|x| x.hash(state));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Map, Value};
+
+    #[test]
+    fn map_usage() {
+        let mut map = Map::new();
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+
+        map.insert("a", 42);
+        assert_eq!(map.len(), 1);
+        assert!(!map.is_empty());
+
+        assert_eq!(map.keys().collect::<Vec<_>>(), vec![&Value::from("a")]);
+        assert_eq!(map.values().collect::<Vec<_>>(), vec![&Value::from(42)]);
+        assert_eq!(
+            map.iter().collect::<Vec<_>>(),
+            vec![(&Value::from("a"), &Value::from(42))]
+        );
+
+        assert_eq!(map.get(&Value::from("a")), Some(&Value::from(42)));
+        assert_eq!(map.get(&Value::from("b")), None);
+        assert_eq!(map.get_mut(&Value::from("a")), Some(&mut Value::from(42)));
+        assert_eq!(map.get_mut(&Value::from("b")), None);
+
+        map[&Value::from("a")] = Value::from(24);
+        assert_eq!(&map[&Value::from("a")], &Value::from(24));
+
+        for (key, value) in map.iter_mut() {
+            if key == &Value::from("a") {
+                *value = Value::from(42);
+            }
+        }
+        assert_eq!(&map[&Value::from("a")], &Value::from(42));
+
+        map.values_mut().for_each(|value| *value = Value::from(24));
+        assert_eq!(&map[&Value::from("a")], &Value::from(24));
+
+        map.insert("b", 42);
+        assert_eq!(map.len(), 2);
+        assert!(!map.is_empty());
+        assert_eq!(map.get(&Value::from("a")), Some(&Value::from(24)));
+        assert_eq!(map.get(&Value::from("b")), Some(&Value::from(42)));
+
+        map.retain(|key, value| {
+            if key == &Value::from("a") {
+                *value = Value::from(42);
+                true
+            } else {
+                false
+            }
+        });
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&Value::from("a")), Some(&Value::from(42)));
+        assert_eq!(map.get(&Value::from("b")), None);
+
+        assert_eq!(map.remove(&Value::from("b")), None);
+        assert_eq!(map.remove(&Value::from("a")), Some(Value::from(42)));
+        assert_eq!(map.remove(&Value::from("a")), None);
+    }
+
+    #[test]
+    fn map_hash() {
+        assert_same_hash(&Map::new(), &Map::new());
+        assert_same_hash(
+            &[("a", 42)].into_iter().collect(),
+            &[("a", 42)].into_iter().collect(),
+        );
+        assert_same_hash(
+            &[("b", 24), ("c", 42)].into_iter().collect(),
+            &[("b", 24), ("c", 42)].into_iter().collect(),
+        );
+    }
+
+    fn assert_same_hash(a: &Map, b: &Map) {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        assert_eq!(a, b);
+        assert!(a.cmp(b).is_eq());
+        assert_eq!(a.partial_cmp(b), Some(std::cmp::Ordering::Equal));
+
+        let mut hasher = DefaultHasher::new();
+        a.hash(&mut hasher);
+        let h1 = hasher.finish();
+
+        let mut hasher = DefaultHasher::new();
+        b.hash(&mut hasher);
+        let h2 = hasher.finish();
+
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn map_index_panic() {
+        let _ = &Map::new()[&Value::Unit];
+    }
+
+    #[test]
+    #[should_panic]
+    fn map_index_mut_panic() {
+        let _ = &mut Map::new()[&Value::Unit];
     }
 }

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -34,7 +34,7 @@ impl Map {
     /// Returns the number of elements in the map.
     #[must_use]
     pub fn len(&self) -> usize {
-        panic!();
+        // panic!();
         self.0.len()
     }
 
@@ -61,7 +61,7 @@ impl Map {
     /// Inserts a new element, returning the previous element with this `key` if
     /// there was any.
     pub fn insert(&mut self, key: Value, value: Value) -> Option<Value> {
-        panic!();
+        // panic!();
         self.0.insert(key, value)
     }
 
@@ -73,7 +73,7 @@ impl Map {
 
     /// Iterate all key-value pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&Value, &Value)> + DoubleEndedIterator {
-        panic!();
+        // panic!();
         self.0.iter()
     }
 

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -27,66 +27,77 @@ type MapInner = indexmap::IndexMap<Value, Value>;
 impl Map {
     /// Creates a new, empty [`Map`].
     #[must_use]
-    pub fn new() -> Map {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Returns the number of elements in the map.
     #[must_use]
     pub fn len(&self) -> usize {
+        panic!();
         self.0.len()
     }
 
     /// Returns `true` if `self.len() == 0`, `false` otherwise.
     #[must_use]
     pub fn is_empty(&self) -> bool {
+        panic!();
         self.0.is_empty()
     }
 
     /// Immutably looks up an element by its `key`.
     #[must_use]
     pub fn get(&self, key: &Value) -> Option<&Value> {
+        panic!();
         self.0.get(key)
     }
 
     /// Mutably looks up an element by its `key`.
     pub fn get_mut(&mut self, key: &Value) -> Option<&mut Value> {
+        panic!();
         self.0.get_mut(key)
     }
 
     /// Inserts a new element, returning the previous element with this `key` if
     /// there was any.
     pub fn insert(&mut self, key: Value, value: Value) -> Option<Value> {
+        panic!();
         self.0.insert(key, value)
     }
 
     /// Removes an element by its `key`.
     pub fn remove(&mut self, key: &Value) -> Option<Value> {
+        panic!();
         self.0.remove(key)
     }
 
     /// Iterate all key-value pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&Value, &Value)> + DoubleEndedIterator {
+        panic!();
         self.0.iter()
     }
 
     /// Iterate all key-value pairs mutably.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Value, &mut Value)> + DoubleEndedIterator {
+        panic!();
         self.0.iter_mut()
     }
 
     /// Iterate all keys.
     pub fn keys(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
+        panic!();
         self.0.keys()
     }
 
     /// Iterate all values.
     pub fn values(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
+        panic!();
         self.0.values()
     }
 
     /// Iterate all values mutably.
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut Value> + DoubleEndedIterator {
+        panic!();
         self.0.values_mut()
     }
 
@@ -100,6 +111,7 @@ impl Map {
     where
         F: FnMut(&Value, &mut Value) -> bool,
     {
+        panic!();
         self.0.retain(keep);
     }
 }
@@ -115,6 +127,7 @@ impl Index<&Value> for Map {
 impl IndexMut<&Value> for Map {
     #[allow(clippy::expect_used)]
     fn index_mut(&mut self, index: &Value) -> &mut Self::Output {
+        panic!();
         self.0.get_mut(index).expect("no entry found for key")
     }
 }
@@ -138,7 +151,7 @@ impl FromIterator<(Value, Value)> for Map {
 /// Note: equality is only given if both values and order of values match
 impl PartialEq for Map {
     fn eq(&self, other: &Map) -> bool {
-        self.cmp(other) == Ordering::Equal
+        self.cmp(other).is_eq()
     }
 }
 
@@ -147,6 +160,7 @@ impl Eq for Map {}
 
 impl PartialOrd for Map {
     fn partial_cmp(&self, other: &Map) -> Option<Ordering> {
+        panic!();
         self.iter().partial_cmp(other.iter())
     }
 }
@@ -159,6 +173,7 @@ impl Ord for Map {
 
 impl Hash for Map {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        panic!();
         self.iter().for_each(|x| x.hash(state));
     }
 }

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -85,7 +85,7 @@ impl Map {
 
     /// Iterate all keys.
     pub fn keys(&self) -> impl Iterator<Item = &Value> + DoubleEndedIterator {
-        panic!();
+        // panic!();
         self.0.keys()
     }
 

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -107,15 +107,16 @@ impl Map {
 impl Index<&Value> for Map {
     type Output = Value;
 
+    #[allow(clippy::expect_used)]
     fn index(&self, index: &Value) -> &Self::Output {
-        &self.0[index]
+        self.get(index).expect("no entry found for key")
     }
 }
 
 impl IndexMut<&Value> for Map {
     #[allow(clippy::expect_used)]
     fn index_mut(&mut self, index: &Value) -> &mut Self::Output {
-        self.0.get_mut(index).expect("no entry found for key")
+        self.get_mut(index).expect("no entry found for key")
     }
 }
 
@@ -261,13 +262,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "no entry found for key")]
     fn map_index_panic() {
         let _ = &Map::new()[&Value::Unit];
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "no entry found for key")]
     fn map_index_mut_panic() {
         let _ = &mut Map::new()[&Value::Unit];
     }

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -17,7 +17,7 @@ use super::Value;
 /// to preserve the order of the parsed map.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct Map(MapInner);
+pub struct Map(pub(crate) MapInner);
 
 #[cfg(not(feature = "indexmap"))]
 type MapInner = std::collections::BTreeMap<Value, Value>;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,6 +1,6 @@
 //! Value module.
 
-use std::{cmp::Eq, hash::Hash};
+use std::{borrow::Cow, cmp::Eq, hash::Hash};
 
 use serde::{
     de::{DeserializeOwned, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor},
@@ -29,6 +29,95 @@ pub enum Value {
     Bytes(Vec<u8>),
     Seq(Vec<Value>),
     Unit,
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<char> for Value {
+    fn from(value: char) -> Self {
+        Self::Char(value)
+    }
+}
+
+impl<K: Into<Value>, V: Into<Value>> FromIterator<(K, V)> for Value {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        Self::Map(iter.into_iter().collect())
+    }
+}
+
+impl From<Map> for Value {
+    fn from(value: Map) -> Self {
+        Self::Map(value)
+    }
+}
+
+impl<T: Into<Number>> From<T> for Value {
+    fn from(value: T) -> Self {
+        Self::Number(value.into())
+    }
+}
+
+impl<T: Into<Value>> From<Option<T>> for Value {
+    fn from(value: Option<T>) -> Self {
+        Self::Option(value.map(Into::into).map(Box::new))
+    }
+}
+
+impl<'a> From<&'a str> for Value {
+    fn from(value: &'a str) -> Self {
+        String::from(value).into()
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Value {
+    fn from(value: Cow<'a, str>) -> Self {
+        String::from(value).into()
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+/// Special case to allow `Value::from(b"byte string")`
+impl<const N: usize> From<&'static [u8; N]> for Value {
+    fn from(value: &'static [u8; N]) -> Self {
+        Self::Bytes(Vec::from(*value))
+    }
+}
+
+impl<T: Into<Value>> FromIterator<T> for Value {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::Seq(iter.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
+    fn from(value: &'a [T]) -> Self {
+        value
+            .into_iter()
+            .map(Clone::clone)
+            .map(Into::into)
+            .collect()
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    fn from(value: Vec<T>) -> Self {
+        value.into_iter().collect()
+    }
+}
+
+impl From<()> for Value {
+    fn from(_value: ()) -> Self {
+        Value::Unit
+    }
 }
 
 impl Value {
@@ -209,24 +298,51 @@ mod tests {
     fn boolean() {
         assert_same::<bool>("true");
         assert_same::<bool>("false");
+
+        assert_eq!(Value::from(true), Value::Bool(true));
+        assert_eq!(Value::from(false), Value::Bool(false));
     }
 
     #[test]
     fn float() {
         assert_same::<f64>("0.123");
         assert_same::<f64>("-4.19");
+
+        assert_eq!(
+            Value::from(42_f32),
+            Value::Number(Number::F32(42_f32.into()))
+        );
+        assert_eq!(
+            Value::from(42_f64),
+            Value::Number(Number::F64(42_f64.into()))
+        );
     }
 
     #[test]
     fn int() {
         assert_same::<u32>("626");
         assert_same::<i32>("-50");
+
+        assert_eq!(Value::from(0_i8), Value::Number(Number::I8(0)));
+        assert_eq!(Value::from(0_i16), Value::Number(Number::I16(0)));
+        assert_eq!(Value::from(0_i32), Value::Number(Number::I32(0)));
+        assert_eq!(Value::from(0_i64), Value::Number(Number::I64(0)));
+        #[cfg(feature = "integer128")]
+        assert_eq!(Value::from(0_i128), Value::Number(Number::I128(0)));
+        assert_eq!(Value::from(0_u8), Value::Number(Number::U8(0)));
+        assert_eq!(Value::from(0_u16), Value::Number(Number::U16(0)));
+        assert_eq!(Value::from(0_u32), Value::Number(Number::U32(0)));
+        assert_eq!(Value::from(0_u64), Value::Number(Number::U64(0)));
+        #[cfg(feature = "integer128")]
+        assert_eq!(Value::from(0_u128), Value::Number(Number::U128(0)));
     }
 
     #[test]
     fn char() {
         assert_same::<char>("'4'");
         assert_same::<char>("'c'");
+
+        assert_eq!(Value::from('🦀'), Value::Char('🦀'));
     }
 
     #[test]
@@ -234,6 +350,16 @@ mod tests {
         assert_same::<String>(r#""hello world""#);
         assert_same::<String>(r#""this is a Rusty 🦀 string""#);
         assert_same::<String>(r#""this is now valid UTF-8 \xf0\x9f\xa6\x80""#);
+
+        assert_eq!(Value::from("slice"), Value::String(String::from("slice")));
+        assert_eq!(
+            Value::from(String::from("string")),
+            Value::String(String::from("string"))
+        );
+        assert_eq!(
+            Value::from(Cow::Borrowed("cow")),
+            Value::String(String::from("cow"))
+        );
     }
 
     #[test]
@@ -242,6 +368,8 @@ mod tests {
         assert_same_bytes::<serde_bytes::ByteBuf>(
             br#"b"this is not valid UTF-8 \xf8\xa1\xa1\xa1\xa1""#,
         );
+
+        assert_eq!(Value::from(b"bytes"), Value::Bytes(Vec::from(*b"bytes")));
     }
 
     #[test]
@@ -252,21 +380,68 @@ mod tests {
 'b': \"Bye\",
         }",
         );
+
+        assert_eq!(Value::from(Map::new()), Value::Map(Map::new()));
+        assert_eq!(
+            Value::from_iter([("a", 42)]),
+            Value::Map({
+                let mut map = Map::new();
+                map.insert(Value::from("a"), Value::from(42));
+                map
+            })
+        );
     }
 
     #[test]
     fn option() {
         assert_same::<Option<char>>("Some('a')");
         assert_same::<Option<char>>("None");
+
+        assert_eq!(Value::from(Option::<bool>::None), Value::Option(None));
+        assert_eq!(
+            Value::from(Some(false)),
+            Value::Option(Some(Box::new(Value::Bool(false))))
+        );
+        assert_eq!(
+            Value::from(Some(Option::<bool>::None)),
+            Value::Option(Some(Box::new(Value::Option(None))))
+        );
     }
 
     #[test]
     fn seq() {
         assert_same::<Vec<f64>>("[1.0, 2.0, 3.0, 4.0]");
+
+        assert_eq!(
+            Value::from([-1_i8, 2, -3].as_slice()),
+            Value::Seq(vec![
+                Value::from(-1_i8),
+                Value::from(2_i8),
+                Value::from(-3_i8)
+            ])
+        );
+        assert_eq!(
+            Value::from(vec![-1_i8, 2, -3]),
+            Value::Seq(vec![
+                Value::from(-1_i8),
+                Value::from(2_i8),
+                Value::from(-3_i8)
+            ])
+        );
+        assert_eq!(
+            Value::from_iter([-1_i8, 2, -3]),
+            Value::Seq(vec![
+                Value::from(-1_i8),
+                Value::from(2_i8),
+                Value::from(-3_i8)
+            ])
+        );
     }
 
     #[test]
     fn unit() {
         assert_same::<()>("()");
+
+        assert_eq!(Value::from(()), Value::Unit);
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -78,6 +78,7 @@ impl<'de> Deserializer<'de> for Value {
                 if items.is_empty() {
                     Ok(value)
                 } else {
+                    panic!();
                     Err(Error::ExpectedDifferentLength {
                         expected: format!("a map of length {}", old_len - items.len()),
                         found: old_len,
@@ -160,11 +161,12 @@ impl<'a, 'de> MapAccess<'de> for MapAccessor<'a> {
     {
         match self.value.take() {
             Some(value) => seed.deserialize(value),
-            None => panic!("Contract violation: value before key"),
+            None => panic!(), //panic!("Contract violation: value before key"),
         }
     }
 
     fn size_hint(&self) -> Option<usize> {
+        panic!();
         Some(self.items.len())
     }
 }

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -142,7 +142,6 @@ macro_rules! float_ty {
         /// See the [`Ord`] implementation.
         impl PartialOrd for $ty {
             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                // panic!();
                 Some(self.cmp(other))
             }
         }
@@ -275,5 +274,12 @@ mod tests {
         assert_eq!(hash(&F32(f32::NAN)), hash(&F32(f32::NAN)));
         assert_eq!(hash(&F32(-f32::NAN)), hash(&F32(-f32::NAN)));
         assert_ne!(hash(&F32(f32::NAN)), hash(&F32(-f32::NAN)));
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        assert!(F32(f32::NAN) > F32(f32::INFINITY));
+        assert!(F32(-f32::NAN) < F32(f32::NEG_INFINITY));
+        assert!(F32(f32::NAN) == F32(f32::NAN));
     }
 }

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -142,6 +142,7 @@ macro_rules! float_ty {
         /// See the [`Ord`] implementation.
         impl PartialOrd for $ty {
             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                panic!();
                 Some(self.cmp(other))
             }
         }

--- a/src/value/number.rs
+++ b/src/value/number.rs
@@ -142,7 +142,7 @@ macro_rules! float_ty {
         /// See the [`Ord`] implementation.
         impl PartialOrd for $ty {
             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                panic!();
+                // panic!();
                 Some(self.cmp(other))
             }
         }

--- a/tests/401_raw_identifier.rs
+++ b/tests/401_raw_identifier.rs
@@ -165,7 +165,7 @@ fn test_invalid_identifiers() {
     let de = ron::from_str::<EmptyStruct>("r#+").unwrap_err();
     assert_eq!(
         format!("{}", de),
-        r#"1:4: Expected struct ""_[invalid identifier] but found `r#+`"#,
+        r#"1:4: Expected only opening `(`, no name, for un-nameable struct"#,
     );
 }
 

--- a/tests/465_unwrap_some_newtype_variant_value.rs
+++ b/tests/465_unwrap_some_newtype_variant_value.rs
@@ -27,9 +27,9 @@ fn deserialise_value_with_unwrap_some_newtype_variant() {
     );
     assert_eq!(
         ron::from_str("#![enable(unwrap_variant_newtypes)] Some(42,)"),
-        Ok(ron::Value::Option(Some(Box::new(ron::Value::Seq(vec![
-            ron::Value::Number(ron::value::Number::U8(42))
-        ]))))),
+        Ok(ron::Value::Option(Some(Box::new(ron::Value::Number(
+            ron::value::Number::U8(42)
+        ))))),
     );
     assert_eq!(
         ron::from_str("#![enable(unwrap_variant_newtypes)] Some()"),


### PR DESCRIPTION
This PR adds more tests to bring `ron` to 100% code lines coverage.

The PR also implements convenient `From` impls for `Value`, e.g. `Value::from(bool)` and `Value::from("my-str")`.

* [x] I've included my change in `CHANGELOG.md`
