### PR TITLE
Fix parsing of struct/variant names starting in `None`, `Some`, `true`, or `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for byte literals as strongly typed unsigned 8-bit integers ([#438](https://github.com/ron-rs/ron/pull/438))
 - Fix issue [#321](https://github.com/ron-rs/ron/issues/321) and allow parsing UTF-8 identifiers ([#488](https://github.com/ron-rs/ron/pull/488))
 - Breaking: Enforce that ron always writes valid UTF-8 ([#488](https://github.com/ron-rs/ron/pull/488))
+- Fix parsing of struct/variant names starting in `None` or `Some` ([#499](https://github.com/ron-rs/ron/pull/499))
 
 ## [0.8.1] - 2023-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for byte literals as strongly typed unsigned 8-bit integers ([#438](https://github.com/ron-rs/ron/pull/438))
 - Fix issue [#321](https://github.com/ron-rs/ron/issues/321) and allow parsing UTF-8 identifiers ([#488](https://github.com/ron-rs/ron/pull/488))
 - Breaking: Enforce that ron always writes valid UTF-8 ([#488](https://github.com/ron-rs/ron/pull/488))
-- Fix parsing of struct/variant names starting in `None` or `Some` ([#499](https://github.com/ron-rs/ron/pull/499))
+- Fix parsing of struct/variant names starting in `None`, `Some`, `true`, or `false` ([#499](https://github.com/ron-rs/ron/pull/499))
 
 ## [0.8.1] - 2023-08-17
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -485,9 +485,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if self.parser.consume_str("None") {
+        if self.parser.consume_ident("None") {
             visitor.visit_none()
-        } else if self.parser.consume_str("Some") && {
+        } else if self.parser.consume_ident("Some") && {
             self.parser.skip_ws()?;
             self.parser.consume_char('(')
         } {

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -451,3 +451,21 @@ fn test_remainder() {
     assert_eq!(deserializer.remainder(), " 37 ");
     assert_eq!(deserializer.end(), Err(Error::TrailingCharacters));
 }
+
+#[test]
+fn boolean_struct_name() {
+    check_from_str_bytes_reader::<bool>(
+        "true_",
+        Err(SpannedError {
+            code: Error::ExpectedBoolean,
+            position: Position { line: 1, col: 1 },
+        }),
+    );
+    check_from_str_bytes_reader::<bool>(
+        "false_",
+        Err(SpannedError {
+            code: Error::ExpectedBoolean,
+            position: Position { line: 1, col: 1 },
+        }),
+    );
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -478,9 +478,9 @@ impl<'a> Parser<'a> {
     }
 
     pub fn bool(&mut self) -> Result<bool> {
-        if self.consume_str("true") {
+        if self.consume_ident("true") {
             Ok(true)
-        } else if self.consume_str("false") {
+        } else if self.consume_ident("false") {
             Ok(false)
         } else {
             Err(Error::ExpectedBoolean)

--- a/tests/367_implicit_some.rs
+++ b/tests/367_implicit_some.rs
@@ -106,3 +106,39 @@ fn test_nested_implicit_some() {
         Ok(Some(Some(Some(5))))
     );
 }
+
+#[test]
+fn fuzzer_found_issues() {
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct Some_();
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct None_();
+
+    let ser_some = ron::ser::to_string_pretty(
+        &Some(Some_()),
+        ron::ser::PrettyConfig::default()
+            .struct_names(true)
+            .extensions(ron::extensions::Extensions::IMPLICIT_SOME),
+    )
+    .unwrap();
+    assert_eq!(ser_some, "#![enable(implicit_some)]\nSome_()");
+
+    let ser_none = ron::ser::to_string_pretty(
+        &Some(None_()),
+        ron::ser::PrettyConfig::default()
+            .struct_names(true)
+            .extensions(ron::extensions::Extensions::IMPLICIT_SOME),
+    )
+    .unwrap();
+    assert_eq!(ser_none, "#![enable(implicit_some)]\nNone_()");
+
+    assert_eq!(
+        ron::from_str::<Option<Some_>>(&ser_some).unwrap(),
+        Some(Some_())
+    );
+    assert_eq!(
+        ron::from_str::<Option<None_>>(&ser_none).unwrap(),
+        Some(None_())
+    );
+}


### PR DESCRIPTION
* [x] I've included my change in `CHANGELOG.md`
