### PR TITLE
Add recursive data cost to fuzzer + speed up `deserialize_any` identifier check

### DIFF
--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -1389,8 +1389,6 @@ impl<'a> SerdeDataType<'a> {
         &mut self,
         u: &mut Unstructured<'u>,
     ) -> arbitrary::Result<SerdeDataValue<'u>> {
-        let u_len = u.len();
-
         let mut name_length: usize = 0;
 
         let value = match self {
@@ -1558,10 +1556,8 @@ impl<'a> SerdeDataType<'a> {
             let _ = u.arbitrary::<bool>()?;
         }
 
-        if u.len() == u_len {
-            // Enforce that producing a value is never free
-            let _ = u.arbitrary::<bool>()?;
-        }
+        // Enforce that producing a value or adding a level is never free
+        let _ = u.arbitrary::<bool>()?;
 
         Ok(value)
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -320,10 +320,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             return visitor.visit_f64(std::f64::NAN);
         }
 
-        // `identifier` does not change state if it fails
-        let ident = self.parser.identifier().ok();
-
-        if let Some(ident) = ident {
+        // `skip_identifier` does not change state if it fails
+        if let Some(ident) = self.parser.skip_identifier() {
             self.parser.skip_ws()?;
 
             return self.handle_any_struct(visitor, Some(ident));

--- a/tests/438_rusty_byte_strings.rs
+++ b/tests/438_rusty_byte_strings.rs
@@ -463,3 +463,22 @@ fn byte_literal() {
         })
     );
 }
+
+#[test]
+fn invalid_identifier() {
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)] // GRCOV_EXCL_LINE
+    struct Test {
+        a: i32,
+    }
+
+    for id in ["b\"", "b'", "br#", "br\"", "r\"", "r#\"", "r##"] {
+        assert_eq!(
+            ron::from_str::<Test>(&format!("({}: 42)", id)).unwrap_err(),
+            SpannedError {
+                code: Error::ExpectedIdentifier,
+                position: Position { line: 1, col: 2 },
+            }
+        );
+    }
+}


### PR DESCRIPTION
Adding layers, e.g. enum variants or tuples, is not without cost in the format, so let's enforce that in the fuzzer as well.

Checking for an identifier in `deserialize_any` previously used the `identifier` parser, which has complex error handling to produce nice error messages. Since we only need to check if one is there, we now use `skip_identifier`, which now returns `Option<&str>` instead of `bool`, and thus avoids any allocation in the check.

~~* [ ] I've included my change in `CHANGELOG.md`~~

* [x] Fix the code coverage regression
