### PR TITLE
Fix missing case of the one-tuple-struct-inside-unwrapped-newtype-variant bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ While data structures with any of these attributes should generally roundtrip th
   - zero-length arrays / tuples / tuple structs / structs / tuple variants / struct variants
     - `Option`s with `#[enable(implicit_some)]` must not contain any of these or a unit, unit struct, or an untagged unit variant
   - externally tagged tuple variants with just one field (that are not newtype variants)
-  - tuples or arrays with just one element are not supported inside newtype variants with `#[enable(unwrap_variant_newtypes)]`
+  - tuples or arrays or tuple structs with just one element are not supported inside newtype variants with `#[enable(unwrap_variant_newtypes)]` (including `Some`)
   - a `ron::value::RawValue`
 - untagged tuple / struct variants with no fields are not supported
 - untagged tuple variants with just one field (that are not newtype variants) are not supported when the `#![enable(unwrap_variant_newtypes)]` extension is enabled

--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -5398,6 +5398,16 @@ impl<'a> SerdeDataType<'a> {
                     return false;
                 }
 
+                if fields.len() == 1
+                    && inside_newtype_variant
+                    && pretty
+                        .extensions
+                        .contains(Extensions::UNWRAP_VARIANT_NEWTYPES)
+                {
+                    // BUG: a one-length tuple struct inside an unwrapped variant newtype will be swallowed
+                    return false;
+                }
+
                 fields
                     .iter()
                     .all(|field| field.supported_inside_untagged(pretty, false, false))

--- a/tests/502_known_bugs.rs
+++ b/tests/502_known_bugs.rs
@@ -736,21 +736,19 @@ fn one_tuple_inside_unwrapped_newtype_variant_inside_adjacently_tagged() {
 #[test]
 fn one_tuple_inside_unwrapped_newtype_variant_inside_untagged() {
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
-    enum A {
-        Newtype((i32,)),
-    }
+    struct OneTuple(i32, #[serde(skip)] ());
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     #[serde(untagged)]
     enum Untagged {
-        B { ho: i32, a: A },
+        B { ho: i32, a: Option<OneTuple> },
     }
 
     assert_eq!(
         check_roundtrip(
             &Untagged::B {
                 ho: 24,
-                a: A::Newtype((42,))
+                a: Some(OneTuple(42, ()))
             },
             PrettyConfig::default()
         ),
@@ -760,7 +758,7 @@ fn one_tuple_inside_unwrapped_newtype_variant_inside_untagged() {
         check_roundtrip(
             &Untagged::B {
                 ho: 24,
-                a: A::Newtype((42,))
+                a: Some(OneTuple(42, ()))
             },
             PrettyConfig::default().extensions(Extensions::UNWRAP_VARIANT_NEWTYPES)
         ),


### PR DESCRIPTION
The fuzzer found an oversight on my end, this PR just amends the existing known bug to another case that is identical to serde.

~~* [ ] I've included my change in `CHANGELOG.md`~~
