### PR TITLE
Fix bug in fuzzer with deny_unknown_fields structs inside flatten

### DIFF
--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -1750,6 +1750,10 @@ impl<'a, 'de> DeserializeSeed<'de> for BorrowedTypedSerdeData<'a> {
                                 ));
                             };
                         }
+                        // flattened structs are incompatible with strict fields
+                        while map.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                            map.next_value::<serde::de::IgnoredAny>().map(|_| ())?;
+                        }
                         Ok(())
                     }
                 }
@@ -2196,6 +2200,11 @@ impl<'a, 'de> DeserializeSeed<'de> for BorrowedTypedSerdeData<'a> {
                                                     .as_str(),
                                                 ));
                                             };
+                                        }
+                                        // flattened struct variants are incompatible with strict fields
+                                        while map.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                                            map.next_value::<serde::de::IgnoredAny>()
+                                                .map(|_| ())?;
                                         }
                                         Ok(())
                                     }
@@ -3720,6 +3729,10 @@ impl<'a, 'de> DeserializeSeed<'de> for BorrowedTypedSerdeData<'a> {
                                             .as_str(),
                                         ));
                                     };
+                                }
+                                // flattened struct variants are incompatible with strict fields
+                                while map.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                                    map.next_value::<serde::de::IgnoredAny>().map(|_| ())?;
                                 }
                                 Ok(())
                             }


### PR DESCRIPTION
Is it a good or bad sign we're now back to finding bugs in the fuzzer itself? Anyways, this one should be fixed now ...

~~* [ ] I've included my change in `CHANGELOG.md`~~
