### PR TITLE
Further flatten fuzzer fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ While data structures with any of these attributes should generally roundtrip th
 
 - ron only supports string keys inside maps flattened into structs
 - internally (or adjacently) tagged or untagged enum variants or `#[serde(flatten)]`ed fields must not contain:
-  - struct names, e.g. by enabling the `PrettyConfig::struct_names` setting
+  - struct names, e.g. by enabling the `#[enable(explicit_struct_names)]` extension or the `PrettyConfig::struct_names` setting
   - newtypes
   - zero-length arrays / tuples / tuple structs / structs / tuple variants / struct variants
     - `Option`s with `#[enable(implicit_some)]` must not contain any of these or a unit, unit struct, or an untagged unit variant

--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -56,11 +56,6 @@ pub fn roundtrip_arbitrary_typed_ron_or_panic(data: &[u8]) -> Option<TypedSerdeD
             Err(err) => panic!("{:#?} -! {:#?}", typed_value, err),
         };
 
-        println!(
-            "{:#?} -> {:#?} -> {}",
-            typed_value.ty, typed_value.value, ron
-        );
-
         if let Err(err) = options.from_str::<ron::Value>(&ron) {
             match err.code {
                 // Erroring on deep recursion is better than crashing on a stack overflow

--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -5152,7 +5152,12 @@ impl<'a> SerdeDataType<'a> {
                         // Flattened fields with maps must fulfil certain criteria
                         return Err(arbitrary::Error::IncorrectFormat);
                     }
-                    if *flatten && pretty.struct_names {
+                    if *flatten
+                        && (pretty.struct_names
+                            || pretty
+                                .extensions
+                                .contains(Extensions::EXPLICIT_STRUCT_NAMES))
+                    {
                         // BUG: struct names inside flattend structs do not roundtrip
                         return Err(arbitrary::Error::IncorrectFormat);
                     }
@@ -5171,7 +5176,7 @@ impl<'a> SerdeDataType<'a> {
                     representation,
                     SerdeEnumRepresentation::Untagged |
                     SerdeEnumRepresentation::InternallyTagged { tag: _ }
-                    if pretty.struct_names
+                    if pretty.struct_names || pretty.extensions.contains(Extensions::EXPLICIT_STRUCT_NAMES)
                 ) {
                     return Err(arbitrary::Error::IncorrectFormat);
                 }
@@ -5311,7 +5316,12 @@ impl<'a> SerdeDataType<'a> {
                                 // Flattened fields with maps must fulfil certain criteria
                                 return Err(arbitrary::Error::IncorrectFormat);
                             }
-                            if *flatten && pretty.struct_names {
+                            if *flatten
+                                && (pretty.struct_names
+                                    || pretty
+                                        .extensions
+                                        .contains(Extensions::EXPLICIT_STRUCT_NAMES))
+                            {
                                 // BUG: struct names inside flattend structs do not roundtrip
                                 return Err(arbitrary::Error::IncorrectFormat);
                             }

--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -5783,6 +5783,11 @@ impl<'a> SerdeDataType<'a> {
                             // BUG: a flattened map will also see the unknown key (serde)
                             return false;
                         }
+                        if *has_unknown_key && is_untagged {
+                            // BUG: an untagged struct will use a map intermediary and see
+                            //      the unknown key (serde)
+                            return false;
+                        }
                         *has_unknown_key = true;
                     }
 
@@ -5851,6 +5856,16 @@ impl<'a> SerdeDataType<'a> {
                             // BUG: an flattened internally tagged newtype alongside other flattened data
                             //      must not contain a unit, unit struct, or untagged unit variant
                             if !inner.supported_inside_internally_tagged_newtype(true) {
+                                return false;
+                            }
+
+                            if !inner.supported_flattened_map_inside_flatten_field(
+                                pretty,
+                                is_flattened,
+                                false,
+                                has_flattened_map,
+                                has_unknown_key,
+                            ) {
                                 return false;
                             }
                         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -612,12 +612,18 @@ impl<'a> Parser<'a> {
                     parser.set_cursor(cursor_backup);
                 }
                 let cursor_backup = parser.cursor;
-                if parser.string().is_err() {
-                    parser.set_cursor(cursor_backup);
+                match parser.string() {
+                    Ok(_) => (),
+                    // prevent quadratic complexity backtracking for unterminated string
+                    Err(err @ (Error::ExpectedStringEnd | Error::Eof)) => return Err(err),
+                    Err(_) => parser.set_cursor(cursor_backup),
                 }
                 let cursor_backup = parser.cursor;
-                if parser.byte_string().is_err() {
-                    parser.set_cursor(cursor_backup);
+                match parser.byte_string() {
+                    Ok(_) => (),
+                    // prevent quadratic complexity backtracking for unterminated byte string
+                    Err(err @ (Error::ExpectedStringEnd | Error::Eof)) => return Err(err),
+                    Err(_) => parser.set_cursor(cursor_backup),
                 }
 
                 let c = parser.next_char()?;

--- a/tests/502_known_bugs.rs
+++ b/tests/502_known_bugs.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, BTreeMap};
+use std::collections::{BTreeMap, HashMap};
 
 use ron::{error::Position, error::SpannedError, extensions::Extensions, ser::PrettyConfig, Error};
 use serde::{Deserialize, Serialize};
@@ -2970,9 +2970,7 @@ fn flattened_map_inside_option_beside_flattened_struct_variant() {
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     #[serde(untagged)]
     enum Untagged {
-        Struct {
-            a: i32,
-        },
+        Struct { a: i32 },
     }
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -3002,12 +3000,8 @@ fn flattened_untagged_struct_beside_flattened_untagged_struct() {
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     #[serde(untagged)]
     enum Untagged {
-        Struct {
-            a: i32,
-        },
-        Other {
-            b: i32,
-        },
+        Struct { a: i32 },
+        Other { b: i32 },
     }
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -3031,66 +3025,6 @@ fn flattened_untagged_struct_beside_flattened_untagged_struct() {
             PrettyConfig::default()
         ),
         Err(Ok(Error::Message(String::from("ROUNDTRIP error: Flattened { a: Struct { a: 42 }, b: Other { b: 24 } } != Flattened { a: Struct { a: 42 }, b: Struct { a: 42 } }"))))
-    );
-}
-
-// TODO: still not fixed
-#[test]
-fn flattened_map_inside_option_beside_struct_with_flattened_field() {
-    #[derive(PartialEq, Debug, Serialize, Deserialize)]
-    #[serde(tag = "tag")]
-    struct Struct {
-        a: i32,
-        #[serde(flatten)]
-        u: (),
-    }
-
-    #[derive(PartialEq, Debug, Serialize, Deserialize)]
-    #[serde(tag = "tag")]
-    struct Flattened {
-        a: Struct,
-        #[serde(flatten)]
-        b: Option<BTreeMap<String, Option<i32>>>,
-    }
-
-    assert_eq!(
-        check_roundtrip(
-            &Flattened {
-                a: Struct {
-                    a: 42,
-                    u: (),
-                },
-                b: Some([(String::from("b"), Some(24))].into_iter().collect()),
-            },
-            PrettyConfig::default()
-        ),
-        Err(Ok(Error::Message(String::from("ROUNDTRIP error: Flattened { a: Struct { a: 42, u: () }, b: Some({\"b\": Some(24)}) } != Flattened { a: Struct { a: 42, u: () }, b: None }"))))
-    );
-}
-
-// TODO: still not fixed
-#[test]
-fn none_inside_flattened_untagged_newtype_variant() {
-    #[derive(PartialEq, Debug, Serialize, Deserialize)]
-    #[serde(untagged)]
-    enum Untagged {
-        Newtype(Option<()>),
-    }
-
-    #[derive(PartialEq, Debug, Serialize, Deserialize)]
-    struct Flattened {
-        #[serde(flatten)]
-        a: Untagged,
-    }
-
-    assert_eq!(
-        check_roundtrip(
-            &Flattened {
-                a: Untagged::Newtype(None),
-            },
-            PrettyConfig::default()
-        ),
-        Err(Err(SpannedError { code: Error::Message(String::from("data did not match any variant of untagged enum Untagged")), position: Position { line: 2, col: 1 } }))
     );
 }
 

--- a/tests/502_known_bugs.rs
+++ b/tests/502_known_bugs.rs
@@ -2966,7 +2966,7 @@ fn flattened_externally_tagged_struct_variant_beside_flattened_intenally_tagged_
 }
 
 #[test]
-fn flattened_map_inside_option_beside_flattened_struct() {
+fn flattened_map_inside_option_beside_flattened_struct_variant() {
     #[derive(PartialEq, Debug, Serialize, Deserialize)]
     #[serde(untagged)]
     enum Untagged {
@@ -2994,6 +2994,103 @@ fn flattened_map_inside_option_beside_flattened_struct() {
             PrettyConfig::default()
         ),
         Err(Ok(Error::Message(String::from("ROUNDTRIP error: Flattened { a: Struct { a: 42 }, b: Some({\"b\": 24}) } != Flattened { a: Struct { a: 42 }, b: Some({\"a\": 42, \"b\": 24}) }"))))
+    );
+}
+
+#[test]
+fn flattened_untagged_struct_beside_flattened_untagged_struct() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum Untagged {
+        Struct {
+            a: i32,
+        },
+        Other {
+            b: i32,
+        },
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct Flattened {
+        #[serde(flatten)]
+        a: Untagged,
+        #[serde(flatten)]
+        b: Untagged,
+    }
+
+    assert_eq!(
+        check_roundtrip(
+            &Flattened {
+                a: Untagged::Struct {
+                    a: 42,
+                },
+                b: Untagged::Other {
+                    b: 24,
+                },
+            },
+            PrettyConfig::default()
+        ),
+        Err(Ok(Error::Message(String::from("ROUNDTRIP error: Flattened { a: Struct { a: 42 }, b: Other { b: 24 } } != Flattened { a: Struct { a: 42 }, b: Struct { a: 42 } }"))))
+    );
+}
+
+// TODO: still not fixed
+#[test]
+fn flattened_map_inside_option_beside_struct_with_flattened_field() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(tag = "tag")]
+    struct Struct {
+        a: i32,
+        #[serde(flatten)]
+        u: (),
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(tag = "tag")]
+    struct Flattened {
+        a: Struct,
+        #[serde(flatten)]
+        b: Option<BTreeMap<String, Option<i32>>>,
+    }
+
+    assert_eq!(
+        check_roundtrip(
+            &Flattened {
+                a: Struct {
+                    a: 42,
+                    u: (),
+                },
+                b: Some([(String::from("b"), Some(24))].into_iter().collect()),
+            },
+            PrettyConfig::default()
+        ),
+        Err(Ok(Error::Message(String::from("ROUNDTRIP error: Flattened { a: Struct { a: 42, u: () }, b: Some({\"b\": Some(24)}) } != Flattened { a: Struct { a: 42, u: () }, b: None }"))))
+    );
+}
+
+// TODO: still not fixed
+#[test]
+fn none_inside_flattened_untagged_newtype_variant() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum Untagged {
+        Newtype(Option<()>),
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct Flattened {
+        #[serde(flatten)]
+        a: Untagged,
+    }
+
+    assert_eq!(
+        check_roundtrip(
+            &Flattened {
+                a: Untagged::Newtype(None),
+            },
+            PrettyConfig::default()
+        ),
+        Err(Err(SpannedError { code: Error::Message(String::from("data did not match any variant of untagged enum Untagged")), position: Position { line: 2, col: 1 } }))
     );
 }
 

--- a/tests/502_known_bugs.rs
+++ b/tests/502_known_bugs.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 
 use ron::{error::Position, error::SpannedError, extensions::Extensions, ser::PrettyConfig, Error};
 use serde::{Deserialize, Serialize};
@@ -2882,6 +2882,118 @@ fn untagged_unit_variant_inside_internally_tagged_newtype_variant_inside_multi_f
             )),
             position: Position { line: 5, col: 1 }
         }))
+    );
+}
+
+#[test]
+fn flattened_externally_tagged_newtype_variant_beside_flattened_intenally_tagged_enum() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    enum ExternallyTagged {
+        Newtype(()),
+        Other(()),
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(tag = "tag")]
+    enum InternallyTagged {
+        Newtype(ExternallyTagged),
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct Flattened {
+        #[serde(flatten)]
+        a: InternallyTagged,
+        #[serde(flatten)]
+        b: ExternallyTagged,
+    }
+
+    assert_eq!(
+        check_roundtrip(
+            &Flattened {
+                a: InternallyTagged::Newtype(ExternallyTagged::Other(())),
+                b: ExternallyTagged::Newtype(()),
+            },
+            PrettyConfig::default()
+        ),
+        Err(Err(SpannedError {
+            code: Error::InvalidValueForType {
+                expected: String::from("map with a single key"),
+                found: String::from("a map"),
+            },
+            position: Position { line: 5, col: 1 }
+        }))
+    );
+}
+
+#[test]
+fn flattened_externally_tagged_struct_variant_beside_flattened_intenally_tagged_enum() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    enum ExternallyTagged {
+        Struct { a: i32 },
+        Other(()),
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(tag = "tag")]
+    enum InternallyTagged {
+        Newtype(ExternallyTagged),
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct Flattened {
+        #[serde(flatten)]
+        a: InternallyTagged,
+        #[serde(flatten)]
+        b: ExternallyTagged,
+    }
+
+    assert_eq!(
+        check_roundtrip(
+            &Flattened {
+                a: InternallyTagged::Newtype(ExternallyTagged::Other(())),
+                b: ExternallyTagged::Struct { a: 42 },
+            },
+            PrettyConfig::default()
+        ),
+        Err(Err(SpannedError {
+            code: Error::InvalidValueForType {
+                expected: String::from("map with a single key"),
+                found: String::from("a map"),
+            },
+            position: Position { line: 7, col: 1 }
+        }))
+    );
+}
+
+#[test]
+fn flattened_map_inside_option_beside_flattened_struct() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum Untagged {
+        Struct {
+            a: i32,
+        },
+    }
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct Flattened {
+        #[serde(flatten)]
+        a: Untagged,
+        #[serde(flatten)]
+        b: Option<BTreeMap<String, i32>>,
+    }
+
+    assert_eq!(
+        check_roundtrip(
+            &Flattened {
+                a: Untagged::Struct {
+                    a: 42,
+                },
+                b: Some([(String::from("b"), 24)].into_iter().collect()),
+            },
+            PrettyConfig::default()
+        ),
+        Err(Ok(Error::Message(String::from("ROUNDTRIP error: Flattened { a: Struct { a: 42 }, b: Some({\"b\": 24}) } != Flattened { a: Struct { a: 42 }, b: Some({\"a\": 42, \"b\": 24}) }"))))
     );
 }
 


### PR DESCRIPTION
~~* [ ] I've included my change in `CHANGELOG.md`~~

This PR is merged early to fix some long-time outstanding fuzzer-found issues. Most bugs are with serde (flattened fields in particular) and our fuzzer is adapted to not trigger them.

This PR should also improve one nasty edge case of parsing complexity.

- [ ] Follow-up this PR with more tests and document newly found restrictions precisely
