### PR TITLE
Limit fuzzer case input size to sensible sizes

### DIFF
--- a/fuzz/fuzz_targets/arbitrary.rs
+++ b/fuzz/fuzz_targets/arbitrary.rs
@@ -22,5 +22,7 @@ use libfuzzer_sys::fuzz_target;
 mod typed_data;
 
 fuzz_target!(|data: &[u8]| {
-    typed_data::roundtrip_arbitrary_typed_ron_or_panic(data);
+    if data.len() < 50_000 {
+        typed_data::roundtrip_arbitrary_typed_ron_or_panic(data);
+    }
 });

--- a/fuzz/fuzz_targets/from_str.rs
+++ b/fuzz/fuzz_targets/from_str.rs
@@ -16,7 +16,9 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &str| {
-    if let Ok(value) = ron::from_str::<ron::Value>(data) {
-        let _ = ron::to_string(&value);
+    if data.len() < 50_000 {
+        if let Ok(value) = ron::from_str::<ron::Value>(data) {
+            let _ = ron::to_string(&value);
+        }
     }
 });


### PR DESCRIPTION
We're not learning anything from 900kB inputs anyways ...

This should only be merged after #534 has landed in the fuzzer results, as it should (hopefully) prevent future OOMs and timeouts that just come from huge inputs

~~* [ ] I've included my change in `CHANGELOG.md`~~
