### PR TITLE
Use/fix ron code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ structs, enums, tuples, arrays, generic maps, and primitive values.
 
 ## Example
 
-```rust,ignore
+```ron
 GameConfig( // optional struct name
     window_size: (800, 600),
     window_title: "PAC-MAN",
@@ -98,7 +98,7 @@ There also is a very basic, work in progress specification available on
 
 ### Same example in RON
 
-```rust,ignore
+```ron
 Scene( // class name is optional
     materials: { // this is a map
         "metal": (

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -21,7 +21,7 @@ struct Object {
 
 Without `unwrap_newtypes`, because the value `5` can not be saved into `NewType(u32)`, your RON document would look like this:
 
-``` ron
+```ron
 (
     new_type: (5),
 )
@@ -29,7 +29,7 @@ Without `unwrap_newtypes`, because the value `5` can not be saved into `NewType(
 
 With the `unwrap_newtypes` extension, this coercion is done automatically. So `5` will be interpreted as `(5)`.
 
-``` ron
+```ron
 #![enable(unwrap_newtypes)]
 (
     new_type: 5,
@@ -98,7 +98,7 @@ pub enum Enum {
 
 Without `unwrap_variant_newtypes`, your RON document would look like this:
 
-``` ron
+```ron
 (
     variant: A(Inner(a: 4, b: true)),
 )
@@ -106,7 +106,7 @@ Without `unwrap_variant_newtypes`, your RON document would look like this:
 
 With the `unwrap_variant_newtypes` extension, the first structural layer inside a newtype variant will be unwrapped automatically:
 
-``` ron
+```ron
 #![enable(unwrap_newtypes)]
 (
     variant: A(a: 4, b: true),


### PR DESCRIPTION
* [ ] I've included my change in `CHANGELOG.md` (I don't think this counts as a "notable change")

Just a heads-up that GitHub now supports RON. This PR
- changes the `rust,ignore` code blocks to `ron`
- changes the ` ron` (leading space) code blocks to `ron`

The downside of this PR is that, while GitHub now detects RON, other tools that render the markdown might not (like crates.io). So perhaps for that reason the `README.md` should be left alone and only the leading spaces should be fixed.
