### PR TITLE
Make use of `Cow<'static, str>` in `PrettyConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: Enforce that ron always writes valid UTF-8 ([#488](https://github.com/ron-rs/ron/pull/488))
 - Add convenient `Value::from` impls ([#498](https://github.com/ron-rs/ron/pull/498))
 - Add new extension `explicit_struct_names` which requires that struct names are included during deserialization ([#522](https://github.com/ron-rs/ron/pull/522))
+- Breaking: Change `PrettyConfig` so that `new_line`, `indentor` and `separator` are all `Cow<'static, str>` instead of `String` ([#546](https://github.com/ron-rs/ron/pull/546))
 
 ### Format Changes
 

--- a/fuzz/fuzz_targets/bench/lib.rs
+++ b/fuzz/fuzz_targets/bench/lib.rs
@@ -144,7 +144,7 @@ impl From<ArbitraryPrettyConfig> for PrettyConfig {
     fn from(arbitrary: ArbitraryPrettyConfig) -> Self {
         Self::default()
             .depth_limit((arbitrary.depth_limit % 16).into())
-            .indentor(String::from(" ")) // conserve some memory and time
+            .indentor(" ") // conserve some memory and time
             .struct_names(arbitrary.struct_names)
             .separate_tuple_members(arbitrary.separate_tuple_members)
             .enumerate_arrays(arbitrary.enumerate_arrays)

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use serde::{ser, ser::Serialize};
 use serde_derive::{Deserialize, Serialize};
@@ -71,7 +71,7 @@ struct Pretty {
 /// let my_config = PrettyConfig::new()
 ///     .depth_limit(4)
 ///     // definitely superior (okay, just joking)
-///     .indentor("\t".to_owned());
+///     .indentor("\t");
 /// ```
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -81,11 +81,11 @@ pub struct PrettyConfig {
     /// Limit the pretty-ness up to the given depth.
     pub depth_limit: usize,
     /// New line string
-    pub new_line: String,
+    pub new_line: Cow<'static, str>,
     /// Indentation string
-    pub indentor: String,
+    pub indentor: Cow<'static, str>,
     /// Separator string
-    pub separator: String,
+    pub separator: Cow<'static, str>,
     // Whether to emit struct names
     pub struct_names: bool,
     /// Separate tuple members with indentation
@@ -135,8 +135,8 @@ impl PrettyConfig {
     ///
     /// Default: `\r\n` on Windows, `\n` otherwise
     #[must_use]
-    pub fn new_line(mut self, new_line: String) -> Self {
-        self.new_line = new_line;
+    pub fn new_line(mut self, new_line: impl Into<Cow<'static, str>>) -> Self {
+        self.new_line = new_line.into();
 
         self
     }
@@ -145,8 +145,8 @@ impl PrettyConfig {
     ///
     /// Default: 4 spaces
     #[must_use]
-    pub fn indentor(mut self, indentor: String) -> Self {
-        self.indentor = indentor;
+    pub fn indentor(mut self, indentor: impl Into<Cow<'static, str>>) -> Self {
+        self.indentor = indentor.into();
 
         self
     }
@@ -155,8 +155,8 @@ impl PrettyConfig {
     ///
     /// Default: 1 space
     #[must_use]
-    pub fn separator(mut self, separator: String) -> Self {
-        self.separator = separator;
+    pub fn separator(mut self, separator: impl Into<Cow<'static, str>>) -> Self {
+        self.separator = separator.into();
 
         self
     }
@@ -344,12 +344,12 @@ impl Default for PrettyConfig {
         PrettyConfig {
             depth_limit: usize::MAX,
             new_line: if cfg!(not(target_os = "windows")) {
-                String::from("\n")
+                Cow::Borrowed("\n")
             } else {
-                String::from("\r\n") // GRCOV_EXCL_LINE
+                Cow::Borrowed("\r\n") // GRCOV_EXCL_LINE
             },
-            indentor: String::from("    "),
-            separator: String::from(" "),
+            indentor: Cow::Borrowed("    "),
+            separator: Cow::Borrowed(" "),
             struct_names: false,
             separate_tuple_members: false,
             enumerate_arrays: false,

--- a/tests/147_empty_sets_serialisation.rs
+++ b/tests/147_empty_sets_serialisation.rs
@@ -37,7 +37,7 @@ fn empty_sets_arrays() {
 
     let pretty = ron::ser::PrettyConfig::new()
         .enumerate_arrays(true)
-        .new_line("\n".to_string());
+        .new_line("\n");
     let serial = ron::ser::to_string_pretty(&value, pretty).unwrap();
 
     println!("Serialized: {}", serial);

--- a/tests/240_array_pretty.rs
+++ b/tests/240_array_pretty.rs
@@ -4,7 +4,7 @@ use ron::ser::{to_string_pretty, PrettyConfig};
 fn small_array() {
     let arr = &[(), (), ()][..];
     assert_eq!(
-        to_string_pretty(&arr, PrettyConfig::new().new_line("\n".to_string())).unwrap(),
+        to_string_pretty(&arr, PrettyConfig::new().new_line("\n")).unwrap(),
         "[
     (),
     (),
@@ -14,9 +14,7 @@ fn small_array() {
     assert_eq!(
         to_string_pretty(
             &arr,
-            PrettyConfig::new()
-                .new_line("\n".to_string())
-                .compact_arrays(true)
+            PrettyConfig::new().new_line("\n").compact_arrays(true)
         )
         .unwrap(),
         "[(), (), ()]"
@@ -25,9 +23,9 @@ fn small_array() {
         to_string_pretty(
             &arr,
             PrettyConfig::new()
-                .new_line("\n".to_string())
+                .new_line("\n")
                 .compact_arrays(true)
-                .separator("".to_string())
+                .separator("")
         )
         .unwrap(),
         "[(),(),()]"
@@ -36,7 +34,7 @@ fn small_array() {
         to_string_pretty(
             &vec![(1, 2), (3, 4)],
             PrettyConfig::new()
-                .new_line("\n".to_string())
+                .new_line("\n")
                 .separate_tuple_members(true)
                 .compact_arrays(true)
         )

--- a/tests/depth_limit.rs
+++ b/tests/depth_limit.rs
@@ -53,7 +53,7 @@ fn depth_limit() {
         .depth_limit(1)
         .separate_tuple_members(true)
         .enumerate_arrays(true)
-        .new_line("\n".to_string());
+        .new_line("\n");
     let s = ron::ser::to_string_pretty(&data, pretty);
 
     assert_eq!(s, Ok(EXPECTED.to_string()));

--- a/tests/preserve_sequence.rs
+++ b/tests/preserve_sequence.rs
@@ -31,7 +31,7 @@ fn make_roundtrip(source: &str) -> String {
         .depth_limit(3)
         .separate_tuple_members(true)
         .enumerate_arrays(true)
-        .new_line("\n".into());
+        .new_line("\n");
     to_string_pretty(&config, pretty).expect("Serialization failed")
 }
 

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -39,31 +39,22 @@ fn test_file_invalid_unicode() {
 #[test]
 fn serialize_invalid_whitespace() {
     assert_eq!(
-        ron::ser::to_string_pretty(
-            &42,
-            ron::ser::PrettyConfig::default().new_line(String::from("a"))
-        )
-        .unwrap_err(),
+        ron::ser::to_string_pretty(&42, ron::ser::PrettyConfig::default().new_line("a"))
+            .unwrap_err(),
         Error::Message(String::from(
             "Invalid non-whitespace `PrettyConfig::new_line`"
         ))
     );
     assert_eq!(
-        ron::ser::to_string_pretty(
-            &42,
-            ron::ser::PrettyConfig::default().indentor(String::from("a"))
-        )
-        .unwrap_err(),
+        ron::ser::to_string_pretty(&42, ron::ser::PrettyConfig::default().indentor("a"))
+            .unwrap_err(),
         Error::Message(String::from(
             "Invalid non-whitespace `PrettyConfig::indentor`"
         ))
     );
     assert_eq!(
-        ron::ser::to_string_pretty(
-            &42,
-            ron::ser::PrettyConfig::default().separator(String::from("a"))
-        )
-        .unwrap_err(),
+        ron::ser::to_string_pretty(&42, ron::ser::PrettyConfig::default().separator("a"))
+            .unwrap_err(),
         Error::Message(String::from(
             "Invalid non-whitespace `PrettyConfig::separator`"
         ))


### PR DESCRIPTION
Fixes #545 by moving all `String` fields in `PrettyConfig` to `Cow<'static, str>`, builder methods are updated to take in `impl Into<Cow<'static, str>>`. I've also removed any conversions to strings in tests/other parts of the codebase.

* [x] I've included my change in `CHANGELOG.md`
