### PR TITLE
Add support for serializing hex strings without quotes

### DIFF
--- a/tests/numbers.rs
+++ b/tests/numbers.rs
@@ -1,6 +1,7 @@
 use ron::{
     de::from_str,
     error::{Error, Position, SpannedError},
+    ser::{to_string_pretty, PrettyConfig},
 };
 
 #[test]
@@ -110,4 +111,36 @@ fn test_dec() {
             position: Position { line: 1, col: 4 },
         })
     );
+}
+
+#[test]
+fn test_hex_serialization() {
+    let config = PrettyConfig::new()
+        .hex_as_raw(true);
+    
+    // Test valid hex without quotes
+    let val = "0x1234";
+    let serialized = to_string_pretty(&val, config.clone()).unwrap();
+    assert_eq!(serialized, "0x1234");
+    
+    // Test uppercase hex
+    let val = "0X1A5B";
+    let serialized = to_string_pretty(&val, config.clone()).unwrap();
+    assert_eq!(serialized, "0X1A5B");
+    
+    // Test that normal strings are still escaped
+    let val = "normal string";
+    let serialized = to_string_pretty(&val, config.clone()).unwrap();
+    assert_eq!(serialized, "\"normal string\"");
+    
+    // Test that invalid hex is treated as a normal string
+    let val = "0xGGG";
+    let serialized = to_string_pretty(&val, config.clone()).unwrap();
+    assert_eq!(serialized, "\"0xGGG\"");
+    
+    // Test with hex_as_raw disabled
+    let config = PrettyConfig::new().hex_as_raw(false);
+    let val = "0x1234";
+    let serialized = to_string_pretty(&val, config).unwrap();
+    assert_eq!(serialized, "\"0x1234\"");
 }


### PR DESCRIPTION
## Problem

Currently, RON supports parsing hex numbers in both quoted and unquoted form:

```ron
number: 0x1234    // works fine
number: "0x1234"  // also works
```

However, when serializing such values, they are always wrapped in quotes:

```rust
pub fn as_hex_u16<S>(value: &u16, serializer: S) -> Result<S::Ok, S::Error>
where
    S: Serializer,
{
    serializer.serialize_str(&format!("0x{:04X}", value))
}

#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
pub struct AddressRange {
    #[serde(serialize_with = "as_hex_u16")]
    pub start: u16,
    #[serde(serialize_with = "as_hex_u16")]
    pub end: u16,
    pub length: u16,
}
```

```ron
start: "0x1234",
end: "0x1235"
length: 2
```

This creates an inconsistency between parsing and serialization capabilities, and makes the serialized output less elegant, especially in configuration files where hex numbers are commonly used (e.g., for colors, flags, or memory addresses).

## Solution

This PR adds a new configuration option `hex_as_raw` (default: `true`) to `PrettyConfig` that allows hex strings to be serialized without quotes. When enabled:

```rust
// Input
let val = "0x1234";
let config = PrettyConfig::new().hex_as_raw(true);
to_string_pretty(&val, config)?;
```

```ron
# Output
number: 0x1234
```

Number is serialised clean and consistent with parsing capabilities.

The implementation includes:

- New `hex_as_raw` configuration option
- Helper function to validate hex string format
- Comprehensive test suite covering various cases
- Full backward compatibility (can be disabled via config)

## Benefits

1. **Consistency**: Serialization now matches RON's existing parsing capabilities
2. **Readability**: Hex numbers without quotes are more readable and familiar
3. **Configurability**: The feature can be enabled/disabled as needed
4. **Safety**: Only valid hex strings (`0x[0-9a-fA-F]+`) are serialized without quotes

This enhancement makes RON's handling of hex numbers more elegant and consistent :)

* [ ] I've included my change in `CHANGELOG.md`
