### PR TITLE
Add `ron-lsp` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,15 @@ fn main() {
 
 ## Tooling
 
-| Editor         | Plugin                                                      |
-| -------------- | ----------------------------------------------------------- |
-| IntelliJ       | [intellij-ron](https://github.com/ron-rs/intellij-ron)      |
-| VS Code        | [a5huynh/vscode-ron](https://github.com/a5huynh/vscode-ron) |
-| Sublime Text   | [RON](https://packagecontrol.io/packages/RON)               |
-| Atom           | [language-ron](https://atom.io/packages/language-ron)       |
-| Vim            | [ron-rs/ron.vim](https://github.com/ron-rs/ron.vim)         |
-| EMACS          | [emacs-ron]                                                 |
-| Multiple / LSP | [ron-lsp](https://github.com/jasonjmcghee/ron-lsp)          |
-
-[emacs-ron]: https://chiselapp.com/user/Hutzdog/repository/ron-mode/home
+| Editor         | Plugin                                                                   |
+| -------------- | ------------------------------------------------------------------------ |
+| IntelliJ       | [intellij-ron](https://github.com/ron-rs/intellij-ron)                   |
+| VS Code        | [a5huynh/vscode-ron](https://github.com/a5huynh/vscode-ron)              |
+| Sublime Text   | [RON](https://packagecontrol.io/packages/RON)                            |
+| Atom           | [language-ron](https://atom.io/packages/language-ron)                    |
+| Vim            | [ron-rs/ron.vim](https://github.com/ron-rs/ron.vim)                      |
+| EMACS          | [emacs-ron](https://chiselapp.com/user/Hutzdog/repository/ron-mode/home) |
+| Multiple / LSP | [ron-lsp](https://github.com/jasonjmcghee/ron-lsp)                       |
 
 ## Limitations
 


### PR DESCRIPTION
I built an [LSP (and CLI)](https://github.com/jasonjmcghee/ron-lsp) that, when coupled with a Rust project, allows diagnostics, auto complete, hover, go-to definition, auto-fix, etc by  associating the RON object with a Rust type.

I implemented a separate tree-sitter for RON in this repo as the only one I could find was missing a fair amount of functionality. This is what is used for parsing / AST.

I implemented support for it in IntelliJ, VS Code, and Neovim as well, but any modern / LSP supporting editor should be able to integrate it easily.

I'm sure there are improvements that could be made and I absolutely welcome them!

* [ ] I've included my change in `CHANGELOG.md`
