### PR TITLE
fix: correct typo in Serializer doc comment

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -413,7 +413,7 @@ impl Default for PrettyConfig {
 
 /// The RON serializer.
 ///
-/// You can just use [`to_string`] for deserializing a value.
+/// You can just use [`to_string`] for serializing a value.
 /// If you want it pretty-printed, take a look at [`to_string_pretty`].
 pub struct Serializer<W: fmt::Write> {
     output: W,


### PR DESCRIPTION
The doc comment on the `Serializer` struct incorrectly says "deserializing" when it should say "serializing". The `to_string` function is a serialization function, not a deserialization function.

**Before:**
\`\`\`rust
/// You can just use [`to_string`] for deserializing a value.
\`\`\`

**After:**
\`\`\`rust
/// You can just use [`to_string`] for serializing a value.
\`\`\`