### PR TITLE
Fix quadratic float parsing in next_bytes_is_float

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1036,10 +1036,20 @@ impl<'a> Parser<'a> {
                 _ => 0,
             };
             let raw_float_len = self.next_chars_while_from_len(skip, is_float_char);
-            // Trim at ".." to avoid treating range operators as float chars
-            let valid_float_len = self.src()[skip..]
+            // Trim at ".." to avoid treating range operators as float chars.
+            //
+            // Only search within the float-char run: the result is clamped to
+            // `raw_float_len` anyway, so a match at or beyond it cannot change the
+            // outcome. Searching the whole remaining input made this O(remaining)
+            // per number, i.e. quadratic in the number count for documents that
+            // contain no ".." at all (every number then scanned to EOF).
+            //
+            // A ".." cannot straddle the end of the run: that would require
+            // `src[raw_float_len] == '.'`, but '.' is a float char and would have
+            // been part of the run. `any_number` above already uses this same
+            // bounded-slice form.
+            let valid_float_len = self.src()[skip..][..raw_float_len]
                 .find("..")
-                .map(|i| i.min(raw_float_len))
                 .map_or(raw_float_len, |i| i.min(raw_float_len));
             let valid_int_len = self.next_chars_while_from_len(skip, is_int_char);
             valid_float_len > valid_int_len

--- a/tests/607_quadratic_float_parsing.rs
+++ b/tests/607_quadratic_float_parsing.rs
@@ -25,10 +25,8 @@ fn seq_of_floats(n: usize) -> String {
 fn parse_millis(n: usize) -> f64 {
     let src = seq_of_floats(n);
     let start = Instant::now();
-    // Bind (and later drop) the parsed value without `std::hint::black_box`,
-    // which is only stable since Rust 1.66 and would break the 1.64 MSRV.
-    // The parse can't be optimized away regardless: `from_str::<Value>` is a
-    // cross-crate, non-inlined call that allocates and is `.unwrap()`ed.
+    // No `black_box` (it needs Rust 1.66, MSRV is 1.64): the unwrapped
+    // cross-crate `from_str` allocates, so the parse isn't optimized away.
     let _value: ron::Value = ron::from_str(&src).unwrap();
     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
     elapsed

--- a/tests/607_quadratic_float_parsing.rs
+++ b/tests/607_quadratic_float_parsing.rs
@@ -1,0 +1,60 @@
+//! Regression test: parsing number-heavy documents must stay linear.
+//!
+//! `Parser::next_bytes_is_float` used to call `find("..")` on the whole remaining
+//! input while clamping the result to the current float-char run, which made every
+//! number scan to EOF on documents containing no `..` at all — quadratic overall.
+//!
+//! The assertion is on *scaling*, not on absolute time, so it stays meaningful on
+//! slow/noisy CI machines: doubling the input should roughly double the work
+//! (ratio ~2). Before the fix the ratio is ~4. The threshold sits far from both.
+
+use std::time::Instant;
+
+fn seq_of_floats(n: usize) -> String {
+    let mut s = String::from("[");
+    for i in 0..n {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str("1234.5678");
+    }
+    s.push(']');
+    s
+}
+
+fn parse_millis(n: usize) -> f64 {
+    let src = seq_of_floats(n);
+    let start = Instant::now();
+    let value: ron::Value = ron::from_str(&src).unwrap();
+    let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+    std::hint::black_box(&value);
+    elapsed
+}
+
+#[test]
+fn parsing_many_floats_scales_linearly() {
+    const N: usize = 10_000;
+
+    // Warm up so allocator/caches don't skew the first sample.
+    parse_millis(N / 10);
+
+    let base = parse_millis(N);
+    let double = parse_millis(N * 2);
+
+    // Guard against a uselessly small denominator on a very fast machine.
+    if base < 1.0 {
+        return;
+    }
+
+    let ratio = double / base;
+    assert!(
+        ratio < 3.0,
+        "parsing {} floats took {:.1}ms but {} floats took {:.1}ms (ratio {:.2}); \
+         expected ~2 (linear), ~4 means the quadratic scan is back",
+        N,
+        base,
+        N * 2,
+        double,
+        ratio
+    );
+}

--- a/tests/607_quadratic_float_parsing.rs
+++ b/tests/607_quadratic_float_parsing.rs
@@ -25,9 +25,12 @@ fn seq_of_floats(n: usize) -> String {
 fn parse_millis(n: usize) -> f64 {
     let src = seq_of_floats(n);
     let start = Instant::now();
-    let value: ron::Value = ron::from_str(&src).unwrap();
+    // Bind (and later drop) the parsed value without `std::hint::black_box`,
+    // which is only stable since Rust 1.66 and would break the 1.64 MSRV.
+    // The parse can't be optimized away regardless: `from_str::<Value>` is a
+    // cross-crate, non-inlined call that allocates and is `.unwrap()`ed.
+    let _value: ron::Value = ron::from_str(&src).unwrap();
     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
-    std::hint::black_box(&value);
     elapsed
 }
 


### PR DESCRIPTION
Fixes #607.

### Problem

`Parser::next_bytes_is_float` searches the **entire remaining input** for `".."`, but clamps the result to the current float-char run:

```rust
let raw_float_len = self.next_chars_while_from_len(skip, is_float_char);
let valid_float_len = self.src()[skip..]
    .find("..")                              // scans to EOF
    .map(|i| i.min(raw_float_len))
    .map_or(raw_float_len, |i| i.min(raw_float_len));
```

Since the result is `.min(raw_float_len)` anyway, every byte scanned past `raw_float_len` is wasted. In a document with no `".."` in it — the common case — `find` scans to EOF for **every number**, making self-describing deserialization (`ron::Value` / `deserialize_any`) O(numbers × input_size).

This regressed in v0.12.2 with #602. Same benchmark, only the version differs (`--release`):

| floats | v0.12.1 | v0.12.2 | slowdown |
|--------|---------|---------|----------|
| 16 000 | 3.2 ms  | 335 ms   | 105× |
| 32 000 | 6.4 ms  | 1 397 ms | 218× |
| 64 000 | 12.2 ms (×1.90) | 5 645 ms (×4.04) | **462×** |

### Fix

Bound the search to the float-char run — the form `any_number` already uses a few lines above:

```rust
let valid_float_len = self.src()[skip..][..raw_float_len]
    .find("..")
    .map_or(raw_float_len, |i| i.min(raw_float_len));
```

Behaviour-preserving:

- A match at index `>= raw_float_len` was already clamped to `raw_float_len`, so not finding it changes nothing.
- A `".."` cannot straddle the end of the run: that would require `src[raw_float_len] == '.'`, but `'.'` is a float char (`is_float_char`) and would have been part of the run.

The now-redundant `.map(|i| i.min(raw_float_len))` before `.map_or(...)` is dropped (`map_or` already re-applies the same `min`).

Result: linear again, **64k floats 5 645 ms → 27 ms (207×)**.

### Tests

- All 453 existing tests pass, including the seven range tests from #602.
- Adds `tests/607_quadratic_float_parsing.rs`, which asserts on **scaling** rather than absolute time so it stays meaningful on slow or noisy CI: the ratio is ~2 when linear, ~4 when quadratic, and the threshold (3.0) sits far from both. It bails out if the baseline is too small to measure.

I verified the test genuinely catches the bug: on the unfixed parser it fails with `ratio 3.90`, and it passes on the fixed one.
