### PR TITLE
Fix quadratic escaped string parsing in escaped_byte_buf

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1217,17 +1217,21 @@ impl<'a> Parser<'a> {
                     },
                 }
 
-                // Checking for '"' and '\\' separately is faster than searching for both at the same time
-                let new_str_end = self.src().find('"').ok_or(Error::ExpectedStringEnd)?;
-                let new_escape = self.src()[..new_str_end].find('\\');
+                // Unlike the non-escaped case above, searching for '"' and '\\'
+                // separately is *not* sound here: `find('"')` scans all the way to
+                // the closing quote, but the cursor only advances by one escape per
+                // iteration, so a string with N escapes rescans the tail N times.
+                // Only the first of '"' / '\\' is needed, and scanning just to the
+                // nearest delimiter keeps the loop linear.
+                let next = self.src().find(['"', '\\']).ok_or(Error::ExpectedStringEnd)?;
+                s.extend_from_slice(&self.src().as_bytes()[..next]);
 
-                if let Some(new_escape) = new_escape {
-                    s.extend_from_slice(&self.src().as_bytes()[..new_escape]);
-                    i = new_escape;
+                // `next` indexes an ASCII byte, so byte indexing is valid here.
+                if self.src().as_bytes()[next] == b'\\' {
+                    i = next;
                 } else {
-                    s.extend_from_slice(&self.src().as_bytes()[..new_str_end]);
                     // Advance to the end of the string + 1 for the `"`.
-                    break Ok((ParsedByteStr::Allocated(s), new_str_end + 1));
+                    break Ok((ParsedByteStr::Allocated(s), next + 1));
                 }
             }
         } else {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1223,7 +1223,10 @@ impl<'a> Parser<'a> {
                 // iteration, so a string with N escapes rescans the tail N times.
                 // Only the first of '"' / '\\' is needed, and scanning just to the
                 // nearest delimiter keeps the loop linear.
-                let next = self.src().find(['"', '\\']).ok_or(Error::ExpectedStringEnd)?;
+                let next = self
+                    .src()
+                    .find(['"', '\\'])
+                    .ok_or(Error::ExpectedStringEnd)?;
                 s.extend_from_slice(&self.src().as_bytes()[..next]);
 
                 // `next` indexes an ASCII byte, so byte indexing is valid here.

--- a/tests/609_quadratic_escaped_string_parsing.rs
+++ b/tests/609_quadratic_escaped_string_parsing.rs
@@ -22,9 +22,12 @@ fn string_of_escapes(n: usize) -> String {
 fn parse_millis(n: usize) -> f64 {
     let src = string_of_escapes(n);
     let start = Instant::now();
-    let value: ron::Value = ron::from_str(&src).unwrap();
+    // Bind (and later drop) the parsed value without `std::hint::black_box`,
+    // which is only stable since Rust 1.66 and would break the 1.64 MSRV.
+    // The parse can't be optimized away regardless: `from_str::<Value>` is a
+    // cross-crate, non-inlined call that allocates and is `.unwrap()`ed.
+    let _value: ron::Value = ron::from_str(&src).unwrap();
     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
-    std::hint::black_box(&value);
     elapsed
 }
 

--- a/tests/609_quadratic_escaped_string_parsing.rs
+++ b/tests/609_quadratic_escaped_string_parsing.rs
@@ -22,10 +22,8 @@ fn string_of_escapes(n: usize) -> String {
 fn parse_millis(n: usize) -> f64 {
     let src = string_of_escapes(n);
     let start = Instant::now();
-    // Bind (and later drop) the parsed value without `std::hint::black_box`,
-    // which is only stable since Rust 1.66 and would break the 1.64 MSRV.
-    // The parse can't be optimized away regardless: `from_str::<Value>` is a
-    // cross-crate, non-inlined call that allocates and is `.unwrap()`ed.
+    // No `black_box` (it needs Rust 1.66, MSRV is 1.64): the unwrapped
+    // cross-crate `from_str` allocates, so the parse isn't optimized away.
     let _value: ron::Value = ron::from_str(&src).unwrap();
     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
     elapsed

--- a/tests/609_quadratic_escaped_string_parsing.rs
+++ b/tests/609_quadratic_escaped_string_parsing.rs
@@ -1,0 +1,72 @@
+//! Regression test: parsing strings with many escapes must stay linear.
+//!
+//! `Parser::escaped_byte_buf` used to call `find('"')` once per escape. That call
+//! scans to the closing quote, while the cursor only advances past one escape per
+//! iteration, so a string with N escapes rescanned the tail N times — quadratic.
+//!
+//! The assertion is on *scaling*, not on absolute time, so it stays meaningful on
+//! slow/noisy CI machines: doubling the input should roughly double the work
+//! (ratio ~2). Before the fix the ratio is ~4. The threshold sits far from both.
+
+use std::time::Instant;
+
+fn string_of_escapes(n: usize) -> String {
+    let mut s = String::from("[\"");
+    for _ in 0..n {
+        s.push_str("\\n");
+    }
+    s.push_str("\"]");
+    s
+}
+
+fn parse_millis(n: usize) -> f64 {
+    let src = string_of_escapes(n);
+    let start = Instant::now();
+    let value: ron::Value = ron::from_str(&src).unwrap();
+    let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+    std::hint::black_box(&value);
+    elapsed
+}
+
+#[test]
+fn parsing_many_escapes_scales_linearly() {
+    const N: usize = 50_000;
+
+    // Warm up so allocator/caches don't skew the first sample.
+    parse_millis(N / 10);
+
+    let base = parse_millis(N);
+    let double = parse_millis(N * 2);
+
+    // Guard against a uselessly small denominator on a very fast machine.
+    if base < 1.0 {
+        return;
+    }
+
+    let ratio = double / base;
+    assert!(
+        ratio < 3.0,
+        "parsing a string with {} escapes took {:.1}ms but {} escapes took {:.1}ms \
+         (ratio {:.2}); expected ~2 (linear), ~4 means the quadratic rescan is back",
+        N,
+        base,
+        N * 2,
+        double,
+        ratio
+    );
+}
+
+/// The escaped path is shared with byte strings, and it is the only path that
+/// allocates — keep a plain correctness check next to the scaling one.
+#[test]
+fn escapes_still_parse_correctly() {
+    assert_eq!(ron::from_str::<String>(r#""a\nb""#).unwrap(), "a\nb");
+    assert_eq!(ron::from_str::<String>(r#""a\"b""#).unwrap(), "a\"b");
+    assert_eq!(ron::from_str::<String>(r#""a\\b""#).unwrap(), "a\\b");
+    assert_eq!(ron::from_str::<String>(r#""\u{41}\u{42}""#).unwrap(), "AB");
+    assert_eq!(ron::from_str::<String>(r#""\n\n\n""#).unwrap(), "\n\n\n");
+    // escape immediately before the closing quote, and an empty tail after it
+    assert_eq!(ron::from_str::<String>(r#""ab\n""#).unwrap(), "ab\n");
+    // no escapes at all still takes the borrowed fast path
+    assert_eq!(ron::from_str::<String>(r#""abc""#).unwrap(), "abc");
+}


### PR DESCRIPTION
Fixes #609.

`escaped_byte_buf` calls `find('"')` once per escape. That call scans from the cursor to
the **closing quote**, while the cursor only advances past **one escape** per iteration —
so a string with N escapes rescans the tail N times, making string parsing O(N²) in the
number of escapes.

Unlike #607, this is not limited to `ron::Value` / `deserialize_any`: it affects any
deserialization of a string containing escapes, including the typed path.

## Root cause

The quadratic scan came in with #534, which replaced a single scan for the first of
`"` / `\\`:

```rust
let (new_i, end_or_escape) = self
    .find_char_index(|c| matches!(c, '\\' | '"'))
    .ok_or(Error::ExpectedStringEnd)?;
```

with "find the closing quote, then look for a backslash before it". That is genuinely
faster for the common **no-escape** case, so this PR keeps it as the fast path *outside*
the loop. Inside the loop, though, only the first of `"` / `\\` is ever needed — scanning
just to the nearest delimiter is both sufficient and linear.

Affected releases (`git tag --contains 08c691d0`): **v0.9.0 … v0.12.2**.

## Result

`["\n\n\n…"]`, release build, at `d0e99bc`:

| input | before | after | ratio before | ratio after |
|---|---|---|---|---|
| 25 KB | 6.64 ms | 0.10 ms | — | — |
| 50 KB | 26.24 ms | 0.19 ms | x3.95 | x1.94 |
| 100 KB | 103.38 ms | 0.38 ms | x3.94 | x1.97 |
| 200 KB | 414.43 ms | 0.76 ms | x4.01 | x2.00 |
| 400 KB | 1652.96 ms | **1.54 ms** | x3.99 | **x2.02** |

**1073x** at 400 KB, and the per-doubling ratio goes from ~4 (quadratic) back to ~2
(linear). Throughput: 0.2 MB/s → 260 MB/s.

Both branches already did the same `extend_from_slice`, so the fix also makes the loop
slightly shorter.

## Tests

The regression test asserts on **scaling**, not absolute time, so it stays meaningful on
slow or noisy CI: the ratio is ~2 when linear and ~4 when quadratic, and the threshold
(3.0) sits far from both. It fails on the pre-fix parser (measured ratio 3.96) and passes
after. Same shape as the test in #608.

The existing suite (453 tests) stays green, plus the 2 new ones.

## Note on error reporting for invalid input

For an unterminated string whose invalid escape follows an escaped quote — e.g.
`"a\"b\c` — this now reports `InvalidEscape` instead of `ExpectedStringEnd`. That is what
the parser did before #534 (verified by running the pre-#534 tree), and it is arguably the
more accurate diagnostic, since there genuinely is an invalid escape.

The outer `find('"')` is deliberately left untouched, so the common case — an unterminated
string with no escapes, e.g. the `(4, "Hello)` case pinned in `de::tests::forgot_apostrophes`
— still reports `ExpectedStringEnd` exactly as today. No existing test changes behaviour.

Happy to preserve the current error exactly if you'd prefer; it costs a little extra state
to track the last found quote across iterations.