### PR TITLE
test: grammar-conformance differential (transcribe docs/grammar.md, diff against the parser)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,25 @@ jobs:
           override: true
       - run: cd fuzz && cargo clippy --all -- -D warnings
 
+  conformance:
+    name: "Conformance: grammar differential"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          key: conformance
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      # The grammar-conformance differential lives in an isolated sub-crate (like
+      # `fuzz/`) so `pest` never enters ron's own dependency graph or MSRV job. It
+      # transcribes docs/grammar.md into a PEG acceptor and diffs it, input by
+      # input, against the parser; a divergence is a parser bug or a doc bug.
+      - run: cd conformance && cargo test -- --nocapture
+
   rustfmt:
     name: "Format: stable"
     runs-on: ubuntu-latest

--- a/conformance/.gitignore
+++ b/conformance/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -1,0 +1,19 @@
+# Grammar-conformance differential for ron. Kept as an isolated sub-crate (like
+# `fuzz/`) so `pest` never enters ron's own dependency graph or its MSRV job:
+# ron's parser is checked against a PEG reference transcribed verbatim from
+# `docs/grammar.md`, and any divergence is a parser bug OR a doc bug.
+[package]
+name = "ron-conformance"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+ron = { path = "..", default-features = false, features = ["std"] }
+serde = { version = "1.0.193", default-features = false, features = ["std"] }
+pest = "2.7"
+pest_derive = "2.7"
+
+# Prevent this from interfering with workspaces (same guard as fuzz/Cargo.toml).
+[workspace]
+members = ["."]

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -1,0 +1,211 @@
+//! Grammar-conformance differential for ron.
+//!
+//! ron ships a human-readable grammar in [`docs/grammar.md`], but nothing checks
+//! that the parser actually agrees with it — there is no grammar-conformance test.
+//! This crate transcribes that EBNF **verbatim** into a PEG acceptor ([`ron.pest`])
+//! and diffs it, input by input, against the real parser. A disagreement is either
+//! a parser bug or a grammar-doc bug.
+//!
+//! The oracle for "does ron accept this as one syntactically-valid value?" is
+//! `Deserializer::from_str -> IgnoredAny::deserialize -> end()`: pure syntactic
+//! validation with the whole input consumed and no data model imposed. (`Value`
+//! is unusable as the oracle — it has no struct/enum/range/byte variants and would
+//! reject or mangle them.)
+//!
+//! Running the differential over a wide battery — hardened by mutation-fuzzing
+//! valid seeds, which is what surfaced the range / char-apostrophe / exponent
+//! findings too subtle to hit by hand — turned up **seven** places where
+//! `docs/grammar.md` disagrees with the parser; in every case the parser is right
+//! and the doc is wrong. They are pinned below in [`KNOWN_DOC_BUGS`] and reported
+//! upstream in ron-rs/ron#614. Everywhere else the transcription and the parser
+//! agree (see the `grammar_conformance` test).
+//!
+//! [`docs/grammar.md`]: https://github.com/ron-rs/ron/blob/master/docs/grammar.md
+//! [`ron.pest`]: ./ron.pest
+
+use pest::Parser;
+use pest_derive::Parser;
+use serde::de::{Deserialize, IgnoredAny};
+
+#[derive(Parser)]
+#[grammar = "ron.pest"]
+struct RonRef;
+
+/// Reference side: does the grammar transcribed from `docs/grammar.md` accept the
+/// whole input as one RON value?
+pub fn ref_accepts(s: &str) -> bool {
+    RonRef::parse(Rule::RON, s).is_ok()
+}
+
+/// Parser side (the oracle): does ron accept the input as exactly one
+/// syntactically-valid value, consuming all of it?
+pub fn ron_accepts(s: &str) -> bool {
+    match ron::Deserializer::from_str(s) {
+        Ok(mut d) => IgnoredAny::deserialize(&mut d).is_ok() && d.end().is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// Inputs where the transcribed grammar and the parser MUST agree. A broad spread
+/// across every production family: if the grammar drifts from the parser here, the
+/// `grammar_conformance` test fails. `(input, note)`.
+pub const CONFORMANT: &[(&str, &str)] = &[
+    // integers / floats / suffixes / bases
+    ("5", "int"),
+    ("-3", "neg int"),
+    ("+5", "explicit plus"),
+    ("05", "leading zero"),
+    ("3.14", "float"),
+    ("1.", "trailing-dot float"),
+    (".5", "leading-dot float"),
+    ("1u8", "int suffix"),
+    ("1.5f32", "float suffix"),
+    ("0x1F", "hex"),
+    ("0b1010", "binary"),
+    ("0o17", "octal"),
+    ("1_000", "digit-group underscores"),
+    ("1e10", "exponent"),
+    ("1E-3", "signed exponent"),
+    ("inf", "inf"),
+    ("-inf", "neg inf"),
+    ("NaN", "NaN"),
+    // bool / option / strings / chars / bytes / idents
+    ("true", "bool"),
+    ("false", "bool"),
+    ("None", "option none"),
+    ("Some(5)", "option some"),
+    ("\"hi\"", "string"),
+    ("\"a\\tb\"", "string with valid escape"),
+    ("\"\\u{1F600}\"", "string unicode escape (braced form)"),
+    ("'a'", "char"),
+    ("'\\''", "escaped-apostrophe char"),
+    ("[1, 2, 3]", "list"),
+    ("{\"a\": 1}", "map"),
+    ("(1, 2)", "tuple"),
+    ("(1, 2,)", "trailing-comma tuple"),
+    ("Foo(1, 2)", "tuple struct"),
+    ("Foo(a: 1)", "named struct"),
+    ("(a: 1)", "anonymous struct"),
+    ("()", "unit"),
+    ("Unit", "unit ident"),
+    ("information", "ident with inf prefix"),
+    ("NaNa", "ident with NaN prefix"),
+    ("r\"raw\"", "raw string, 0 hashes"),
+    ("r#\"a\"b\"#", "raw string, 1 hash with inner quote"),
+    ("b\"bytes\"", "byte string"),
+    ("b'x'", "byte literal"),
+    ("br\"raw\"", "raw byte string"),
+    ("r#name", "raw ident"),
+    // ranges (adjacent operator — the whitespace variants are finding D)
+    ("1..2", "range excl"),
+    ("1..=2", "range incl"),
+    ("..2", "range to excl"),
+    ("..=2", "range to incl"),
+    ("1..", "range from"),
+    ("..", "range full"),
+    // extensions / comments / whitespace
+    ("#![enable(implicit_some)] 5", "extension header"),
+    ("#![enable(unwrap_newtypes)]\n(a: 1)", "extension + struct"),
+    ("/* c */ 5", "block comment"),
+    ("// c\n5", "line comment"),
+    ("/* /* nested */ */ 5", "nested block comment"),
+    // malformed — both must REJECT
+    ("5 5", "two values"),
+    ("5,", "trailing comma at top level"),
+    ("0x", "empty hex"),
+    ("1e", "empty exponent"),
+    ("1__2", "double underscore between digits"),
+    ("\"unterminated", "unterminated string"),
+    ("[1, 2", "unterminated list"),
+    ("", "empty input"),
+    ("   ", "whitespace only"),
+];
+
+/// A place where `docs/grammar.md` disagrees with the parser. Self-checking: the
+/// test asserts `ref_accepts(input) == doc_accepts` (the transcription is faithful
+/// to the doc), `ron_accepts(input) == parser_accepts` (the parser behaves as
+/// claimed), and `doc_accepts != parser_accepts` (this really is a divergence). A
+/// wrong field therefore fails the test loudly rather than passing silently.
+pub struct DocBug {
+    /// finding id in ron-rs/ron#614
+    pub finding: &'static str,
+    pub input: &'static str,
+    /// what a verbatim reading of `docs/grammar.md` does == `ref_accepts(input)`
+    pub doc_accepts: bool,
+    /// what the parser actually does (the correct behaviour)
+    pub parser_accepts: bool,
+    pub summary: &'static str,
+}
+
+/// The seven divergences reported in ron-rs/ron#614. In every row the parser is
+/// right; the grammar doc is wrong. These are the ONLY inputs on which the
+/// verbatim transcription and the parser disagree.
+pub const KNOWN_DOC_BUGS: &[DocBug] = &[
+    DocBug {
+        finding: "A",
+        input: "\"a\\c\"", // "a\c"
+        doc_accepts: true,
+        parser_accepts: false,
+        summary: "string_std: `no_double_quotation_marks` lets a lone `\\` be literal; \
+                  the parser requires every `\\` to start a valid escape.",
+    },
+    DocBug {
+        finding: "B",
+        input: "'\\n'", // '\n'
+        doc_accepts: false,
+        parser_accepts: true,
+        summary: "char: grammar allows only `\\\\` / `\\'`, but the parser accepts the \
+                  full string escape set (`\\n`, `\\x41`, `\\u{..}`).",
+    },
+    DocBug {
+        finding: "C",
+        input: "\"\\uFFFF\"", // "￿" — the braceless doc form
+        doc_accepts: true,
+        parser_accepts: false,
+        summary: "escape_unicode: grammar is `\\u` + bare hex; the parser requires \
+                  `\\u{ 1..=6 hex }`.",
+    },
+    DocBug {
+        finding: "D",
+        input: "1 ..2", // whitespace before the range operator
+        doc_accepts: true,
+        parser_accepts: false,
+        summary: "range_*: grammar puts `ws` around `..`/`..=`; the parser consumes the \
+                  operator adjacent, with no skip_ws.",
+    },
+    DocBug {
+        finding: "E",
+        input: "'''", // a bare apostrophe as the char content
+        doc_accepts: false,
+        parser_accepts: true,
+        summary: "char: `no_apostrophe` says a `'` inside a char must be escaped, but the \
+                  parser takes a bare `'` as-is (`'''` is the char `'`).",
+    },
+    DocBug {
+        finding: "F",
+        input: "1e_+0", // underscore before the exponent sign
+        doc_accepts: false,
+        parser_accepts: true,
+        summary: "float_exp: grammar puts the sign strictly before any `_`; the parser \
+                  allows `_` after `e`/`E`, i.e. before the sign.",
+    },
+    DocBug {
+        finding: "G",
+        input: " #![enable(implicit_some)]\n(a: 1)", // leading ws before extensions
+        doc_accepts: false,
+        parser_accepts: true,
+        summary: "RON: nothing precedes `[extensions]` in the grammar, but the parser \
+                  accepts leading whitespace/comments before `#![enable(..)]`.",
+    },
+];
+
+/// Inputs that are syntactically valid (the grammar accepts them) but that ron
+/// rejects for **semantic** reasons layered on top of the syntax. These are NOT
+/// grammar-doc bugs and must not be "fixed" in `docs/grammar.md`; they are pinned
+/// so a differential does not mistake them for conformance gaps. Asserted as
+/// `ref_accepts == true && ron_accepts == false`.
+pub const SEMANTIC_NOT_GRAMMAR: &[(&str, &str)] = &[
+    ("911u8", "integer does not fit its suffix (911 > u8::MAX)"),
+    ("-1u8", "negative value with an unsigned suffix"),
+    ("Some()", "`Some` is reserved for Option and needs exactly one inner value"),
+];

--- a/conformance/src/ron.pest
+++ b/conformance/src/ron.pest
@@ -1,0 +1,163 @@
+// PEG acceptor for RON, transcribed from docs/grammar.md.
+//
+// A pure acceptor: it only decides whether a string is one valid RON value,
+// never which production matched. A divergence from the parser means either a
+// parser bug or a grammar-doc bug.
+//
+// There is deliberately no `WHITESPACE` rule, so pest inserts no implicit
+// whitespace; every `ws` is threaded explicitly, as the grammar does.
+//
+// Each deviation from a verbatim transcription is tagged `ADAPT:` with a reason.
+
+// ADAPT: `extensions` are optional (spec `[extensions]`), realized as `*`.
+RON = { SOI ~ extensions ~ ws ~ value ~ ws ~ EOI }
+
+// ---------------------------------------------------------------- whitespace
+ws         = { (ws_single | comment)* }
+ws_single  = { "\n" | "\t" | "\r" | " "
+             | "\u{000B}" | "\u{000C}" | "\u{0085}"
+             | "\u{200E}" | "\u{200F}" | "\u{2028}" | "\u{2029}" }
+
+// ADAPT: spec wraps each comment form in `[...]` (optional), which lets a
+// comment match empty — treated here as a plain ordered choice.
+comment       = { line_comment | block_comment }
+// ADAPT: allow a `//` line comment to be closed by EOI, not only "\n".
+line_comment  = { "//" ~ (!"\n" ~ ANY)* ~ ("\n" | EOI) }
+block_comment = { "/*" ~ (block_comment | (!"*/" ~ ANY))* ~ "*/" }
+
+comma = { ws ~ "," ~ ws }
+
+// ---------------------------------------------------------------- extensions
+extensions       = { extension_decl* }
+extension_decl   = { "#" ~ ws ~ "!" ~ ws ~ "[" ~ ws ~ extensions_inner ~ ws ~ "]" ~ ws }
+extensions_inner = { "enable" ~ ws ~ "(" ~ ws ~ extension_name ~ (comma ~ extension_name)* ~ comma? ~ ws ~ ")" }
+// Spec defers to extensions.md for valid names; ron enforces this CLOSED set,
+// so the reference does too (an open ident class would falsely accept typo'd
+// names that ron rejects — a semantic, not syntactic, distinction).
+extension_name   = { "implicit_some" | "unwrap_newtypes" | "unwrap_variant_newtypes" }
+
+// -------------------------------------------------------------------- value
+// Spec: value = integer | byte | float | string | byte_string | char | bool
+//             | option | list | map | tuple | struct | enum_variant | range
+//
+// ADAPT: ordering is the substance of the PEG realization.
+//  * ranges come first so `1..2` / `..2` aren't committed to a bare number.
+//  * numbers are one maximal-munch token (like ron's `any_number`), not the
+//    spec's integer|byte|float split (which mis-handles `1u8` vs `1.5` in a PEG).
+//  * bool / option / anonymous tuple all fold into `composite` (ident + optional
+//    paren body); for a pure acceptor only the union matters, not which arm wins.
+value = {
+      prefix_range
+    | atom_or_range
+    | byte_string_raw | byte_string_std | byte
+    | string_raw | string_std
+    | char
+    | list
+    | map
+    | composite
+}
+
+// ---------------------------------------------------------------- numbers
+// ADAPT: one maximal-munch numeric token (like ron's `any_number`); the spec's
+// integer|byte|float split can't be transcribed verbatim in a PEG. The suffix
+// stays coupled to the body shape, as the spec's integer_suffix/float_suffix do:
+//   * hex/oct/bin           -> int_suffix only
+//   * decimal with dot/exp  -> float_suffix only
+//   * bare decimal digits   -> either
+number = @{ sign? ~ number_body }
+sign   = { "+" | "-" }
+
+number_body = {
+      special_float ~ float_suffix?
+    | based_int ~ int_suffix?
+    | dec_float ~ float_suffix?
+    | int_part ~ (int_suffix | float_suffix)?
+}
+
+special_float = { ("inf" | "NaN") ~ !xid_continue } // ADAPT: word boundary so `information` stays an ident
+
+// A base-digit is REQUIRED immediately after the prefix
+// (spec: unsigned_hexadecimal = "0x", digit_hex, { digit_hex | "_" }).
+based_int = { "0b" ~ digit_binary ~ (digit_binary | "_")*
+            | "0o" ~ digit_octal ~ (digit_octal | "_")*
+            | "0x" ~ digit_hex ~ (digit_hex | "_")* }
+
+// decimal carrying a float marker (dot and/or exponent).
+dec_float     = { int_part ~ (trailing_frac ~ exp? | exp) | leading_frac ~ exp? }
+int_part      = { digit ~ (digit | "_")* }
+// spec float_std: integer part then ".", fractional digits OPTIONAL (`1.`).
+// ADAPT: `!"."` so `1..2` (range) does not munch the first `.` as `1.` — ron
+// gives the `..` range operator precedence over a trailing-dot float.
+trailing_frac = { "." ~ !"." ~ (digit ~ (digit | "_")*)? }
+// spec float_frac: ".", then at least one digit REQUIRED (`.5`, never bare `.`).
+leading_frac  = { "." ~ !"." ~ digit ~ (digit | "_")* }
+// ADAPT: pest `*` is possessive (no backtracking), so the spec's
+// `{digit|_}, digit, {digit|_}` cannot be transcribed verbatim. Equivalent:
+// optional underscores, then a required digit, then any digits/underscores.
+exp           = { ("e" | "E") ~ sign? ~ "_"* ~ digit ~ (digit | "_")* }
+
+int_suffix    = { ("i" | "u") ~ ("8" | "16" | "32" | "64" | "128") }
+float_suffix  = { "f" ~ ("32" | "64") }
+
+digit         = { '0'..'9' }
+digit_binary  = { '0'..'1' }
+digit_octal   = { '0'..'7' }
+digit_hex     = { '0'..'9' | 'a'..'f' | 'A'..'F' }
+
+// ---------------------------------------------------------------- ranges
+// from-forms: number, then optionally a `..`/`..=` tail (with optional bound).
+atom_or_range   = { number ~ range_from_tail? }
+range_from_tail = { ws ~ ("..=" ~ ws ~ number | ".." ~ ws ~ number | "..") }
+// to-forms and full range.
+prefix_range    = { "..=" ~ ws ~ number | ".." ~ ws ~ number | ".." }
+
+// ---------------------------------------------------------------- byte
+byte         = { "b'" ~ byte_content ~ "'" }
+byte_content = { ("\\" ~ (escape_ascii | escape_byte)) | ASCII }
+
+// ---------------------------------------------------------------- strings
+// ADAPT (faithful): `no_double_quotation_marks` excludes only `"`, so a lone
+// backslash is a literal char here. `string_escape` is tried first, but when it
+// fails (invalid escape) the char still matches as literal. This is exactly the
+// spec's loose semantics — and where ron is expected to be *stricter*.
+string_std    = @{ "\"" ~ (string_escape | (!"\"" ~ ANY))* ~ "\"" }
+string_escape = { "\\" ~ (escape_ascii | escape_byte | escape_unicode) }
+escape_ascii  = { "'" | "\"" | "\\" | "n" | "r" | "t" | "0" }
+escape_byte   = { "x" ~ digit_hex ~ digit_hex }
+escape_unicode= { "u" ~ digit_hex ~ (digit_hex ~ (digit_hex ~ (digit_hex ~ (digit_hex ~ digit_hex?)?)?)?)? }
+
+// Raw strings via pest's stack (context-sensitive `#`^n delimiter) — the one
+// production the spec says "cannot be written in EBNF".
+string_raw    = @{ "r" ~ raw_body }
+byte_string_std = @{ "b\"" ~ (string_escape | (!"\"" ~ ANY))* ~ "\"" }
+byte_string_raw = @{ "br" ~ raw_body }
+raw_body      = @{ PUSH("#"*) ~ "\"" ~ (!("\"" ~ PEEK) ~ ANY)* ~ "\"" ~ POP }
+
+// ---------------------------------------------------------------- char
+// ADAPT (faithful): spec allows only `\\` and `\'` escapes plus any single
+// non-apostrophe char — so `'\n'` is expected to be *rejected* here while ron
+// accepts it. Divergence = spec-doc gap.
+char        = @{ "'" ~ (char_escape | (!"'" ~ ANY)) ~ "'" }
+char_escape = { "\\\\" | "\\'" }
+
+// ---------------------------------------------------------------- collections
+list = { "[" ~ ws ~ (value ~ (comma ~ value)* ~ comma?)? ~ ws ~ "]" }
+map  = { "{" ~ ws ~ (map_entry ~ (comma ~ map_entry)* ~ comma?)? ~ ws ~ "}" }
+map_entry = { value ~ ws ~ ":" ~ ws ~ value }
+
+// composite = anonymous tuple / struct / enum-variant / bool / option / unit.
+// ident? then an optional parenthesized body (values OR named fields).
+composite  = { ident ~ (ws ~ paren)? | paren }
+paren      = { "(" ~ ws ~ paren_body? ~ ws ~ ")" }
+paren_body = { named_fields | value_seq }
+named_fields = { named_field ~ (comma ~ named_field)* ~ comma? }
+named_field  = { ident ~ ws ~ ":" ~ ws ~ value }
+value_seq    = { value ~ (comma ~ value)* ~ comma? }
+
+// ---------------------------------------------------------------- identifiers
+ident        = { ident_raw | ident_std }
+ident_std    = @{ ident_std_first ~ xid_continue* }
+ident_std_first = { XID_START | "_" }
+ident_raw    = @{ "r#" ~ ident_raw_rest+ }
+ident_raw_rest  = { xid_continue | "." | "+" | "-" }
+xid_continue = { XID_CONTINUE }

--- a/conformance/tests/grammar_conformance.rs
+++ b/conformance/tests/grammar_conformance.rs
@@ -1,0 +1,106 @@
+//! Grammar-conformance differential: the grammar transcribed verbatim from
+//! `docs/grammar.md` (`src/ron.pest`) vs the real parser.
+//!
+//! Run in the dedicated CI job (see the "Conformance" job in ci.yaml):
+//!
+//! ```text
+//! cargo test --manifest-path conformance/Cargo.toml -- --nocapture
+//! ```
+
+use ron_conformance::{
+    ref_accepts, ron_accepts, CONFORMANT, KNOWN_DOC_BUGS, SEMANTIC_NOT_GRAMMAR,
+};
+
+fn yn(b: bool) -> &'static str {
+    if b {
+        "accept"
+    } else {
+        "reject"
+    }
+}
+
+/// The grammar and the parser agree everywhere in the conformant battery.
+#[test]
+fn conformant_battery_agrees() {
+    let mut mismatches = Vec::new();
+    for (input, note) in CONFORMANT {
+        let r = ref_accepts(input);
+        let o = ron_accepts(input);
+        if r != o {
+            mismatches.push(format!(
+                "  `{}` ({}): grammar {} vs parser {}",
+                input.escape_debug(),
+                note,
+                yn(r),
+                yn(o)
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "grammar/parser disagree on inputs that should conform \
+         (if intentional, move them to KNOWN_DOC_BUGS):\n{}",
+        mismatches.join("\n"),
+    );
+}
+
+/// Each of the seven ron-rs/ron#614 findings is real and pinned: the transcription
+/// is faithful to the doc, the parser behaves as claimed, and the two disagree.
+#[test]
+fn known_doc_bugs_are_real() {
+    for bug in KNOWN_DOC_BUGS {
+        let r = ref_accepts(bug.input);
+        let o = ron_accepts(bug.input);
+
+        assert_eq!(
+            r, bug.doc_accepts,
+            "finding {}: transcription of docs/grammar.md should {} `{}` — {}",
+            bug.finding,
+            yn(bug.doc_accepts),
+            bug.input.escape_debug(),
+            bug.summary,
+        );
+        assert_eq!(
+            o, bug.parser_accepts,
+            "finding {}: the parser should {} `{}` — {}",
+            bug.finding,
+            yn(bug.parser_accepts),
+            bug.input.escape_debug(),
+            bug.summary,
+        );
+        assert_ne!(
+            bug.doc_accepts, bug.parser_accepts,
+            "finding {}: doc and parser must actually disagree — {}",
+            bug.finding, bug.summary,
+        );
+        println!(
+            "finding {}: `{}`  doc={}  parser={}  — {}",
+            bug.finding,
+            bug.input.escape_debug(),
+            yn(bug.doc_accepts),
+            yn(bug.parser_accepts),
+            bug.summary,
+        );
+    }
+}
+
+/// Syntactically-valid inputs that ron rejects for semantic reasons are NOT
+/// grammar-doc bugs: the grammar accepts them, the parser rejects them, and
+/// `docs/grammar.md` should not change.
+#[test]
+fn semantic_rejections_are_not_grammar_bugs() {
+    for (input, note) in SEMANTIC_NOT_GRAMMAR {
+        assert!(
+            ref_accepts(input),
+            "`{}` ({}) should be syntactically accepted by the grammar",
+            input,
+            note
+        );
+        assert!(
+            !ron_accepts(input),
+            "`{}` ({}) should be rejected by the parser (semantic layer)",
+            input,
+            note
+        );
+    }
+}


### PR DESCRIPTION
## What

ron has ~450 correctness tests but nothing checks that the parser agrees with the
grammar it documents in
[`docs/grammar.md`](https://github.com/ron-rs/ron/blob/master/docs/grammar.md) —
there is no grammar-conformance test.

This adds one. `conformance/` is an isolated sub-crate — the same trick as
`fuzz/` (its own `[workspace]`), so **`pest` never enters ron's own dependency
graph or the MSRV job**. It transcribes the EBNF **verbatim** into a PEG acceptor
(`conformance/src/ron.pest`) and diffs it, input by input, against the parser. A
disagreement is either a parser bug or a grammar-doc bug.

The oracle for "does ron accept this as one syntactically-valid value?" is
`Deserializer::from_str -> IgnoredAny::deserialize -> end()`: pure syntactic
validation, whole input consumed, no data model imposed. (`Value` can't be the
oracle — it lacks struct/enum/range/byte variants and would reject or mangle them.)

## What it found

Building the differential surfaced **seven** places where `docs/grammar.md`
disagrees with the parser — in every case the parser is right and the doc is
wrong. They are filed as #614 and pinned here in `KNOWN_DOC_BUGS`:

| # | input | doc | parser | gap |
|---|-------|-----|--------|-----|
| A | `"a\c"` | accept | reject | a lone `\` must start a valid escape |
| B | `'\n'` | reject | accept | char takes the full string escape set |
| C | `"￿"` | accept | reject | `\u` requires `{ 1..=6 hex }` |
| D | `1 ..2` | accept | reject | no whitespace around range operators |
| E | `'''` | reject | accept | a bare `'` is accepted as char content |
| F | `1e_+0` | reject | accept | `_` allowed before the exponent sign |
| G | ` #![enable(..)]` | reject | accept | leading whitespace before extensions |

Each row is a **self-checking** assertion: the transcription is faithful to the
doc, the parser behaves as claimed, and the two disagree — a wrong expectation
fails loudly instead of passing silently. Everywhere else (the `CONFORMANT`
battery, spanning every production family) the transcription and the parser agree.

Inputs ron rejects for **semantic** reasons (`911u8`, `-1u8`, `Some()`) are pinned
separately in `SEMANTIC_NOT_GRAMMAR`, so the differential does not mistake them for
conformance gaps.

## CI

A dedicated `Conformance` job runs `cd conformance && cargo test`, isolated from the
main test / MSRV matrix (`pest` is pulled into this job only).

## Note

This is the executable evidence behind #614. If useful, I'm happy to also open the
`grammar.md` fix PR; once the doc is corrected the `KNOWN_DOC_BUGS` entries fold
into the conformant battery and the divergence set goes to zero, leaving the test
as a guard against any new drift.
